### PR TITLE
Handle supported languages with no example audio file

### DIFF
--- a/ovos_stt_http_server/__main__.py
+++ b/ovos_stt_http_server/__main__.py
@@ -27,6 +27,8 @@ def main():
                         default="en-us")
     parser.add_argument("--gradio", help="Enable Gradio Web UI",
                         action="store_true")
+    parser.add_argument("--cache", help="Cache models for Gradio demo",
+                        action="store_true")
     parser.add_argument("--title", help="Title for webUI",
                         default="STT")
     parser.add_argument("--description", help="Text description to print in UI",
@@ -40,7 +42,7 @@ def main():
     LOG.info("Server Started")
     if args.gradio:
         bind_gradio_service(server, engine, args.title, args.description,
-                            args.info, args.badge, args.lang)
+                            args.info, args.badge, args.lang, args.cache)
         LOG.info("Gradio Started")
     uvicorn.run(server, host=args.host, port=args.port)
 

--- a/ovos_stt_http_server/gradio_app.py
+++ b/ovos_stt_http_server/gradio_app.py
@@ -16,7 +16,7 @@ def transcribe(audio_file, language: str):
 
 def bind_gradio_service(app, stt_engine: ModelContainer,
                         title, description, info, badge,
-                        default_lang="en"):
+                        default_lang="en", cache=True):
     global STT
     STT = stt_engine
     languages = list(stt_engine.plugin().available_languages or [default_lang])
@@ -47,7 +47,7 @@ def bind_gradio_service(app, stt_engine: ModelContainer,
             "textbox"
         ],
         examples=[[e, basename(splitext(e)[0])] for e in examples],
-        cache_examples=True,  # Takes some time at init, but speeds up runtime
+        cache_examples=cache,  # Takes some time at init, but speeds up runtime
         live=True,
         title=title,
         description=description,

--- a/ovos_stt_http_server/gradio_app.py
+++ b/ovos_stt_http_server/gradio_app.py
@@ -1,7 +1,7 @@
 
 import gradio as gr
 
-from os.path import join, dirname, basename, splitext
+from os.path import join, dirname, basename, splitext, isfile
 from ovos_utils.log import LOG
 from ovos_stt_http_server import ModelContainer, bytes2audiodata
 
@@ -32,6 +32,7 @@ def bind_gradio_service(app, stt_engine: ModelContainer,
 
     examples = [join(dirname(__file__), 'audio', f'{lang.split("-")[0]}.mp3')
                 for lang in languages]
+    examples = [example for example in examples if isfile(example)]
     iface = gr.Interface(
         fn=transcribe,
         inputs=[

--- a/readme.md
+++ b/readme.md
@@ -13,12 +13,19 @@ ovos-stt-server --help
 usage: ovos-stt-server [-h] [--engine ENGINE] [--port PORT] [--host HOST]
 
 options:
-  -h, --help       show this help message and exit
-  --engine ENGINE  stt plugin to be used
-  --port PORT      port number
-  --host HOST      host
+  -h, --help                  show this help message and exit
+  --engine ENGINE             stt plugin to be used
+  --port PORT                 port number
+  --host HOST                 host
+  --lang LANG                 default language
+  --gradio                    flag to enable Gradio web UI
+  --cache                     flag to pre-cache examples in Gradio web UI
+  --title TITLE               title for Gradio UI
+  --description DESCRIPTION   Description for Gradio UI
+  --info INFO                 Text to display in Gradio UI
+  --badge BADGE               URL of badge to show in Gradio UI
 ```
-
+> Note: `ffmpeg` is required for Gradio
 ## Companion plugin
 
 Use with OpenVoiceOS [companion plugin](https://github.com/OpenVoiceOS/ovos-stt-server-plugin)


### PR DESCRIPTION
Fix for bug related to audio examples reported [on Matrix] (https://matrix.to/#/!EOygeDJPfJQOfNacqH:matrix.org/$sszoDSgsMrGAsqx1XeGnJiEcZ2UKujjwdtCWDvqJaR4?via=matrix.org&via=cyberia.club&via=mozilla.org) by @goldyfruit 
Updates documentation
Makes cache optional at init