### PR TITLE
Fix docker endpoint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ RUN pip3 install ovos-stt-http-server==0.0.1
 
 RUN pip3 install {PLUGIN_HERE}
 
-ENTRYPOINT ovos-stt-http-server --engine {PLUGIN_HERE}
+ENTRYPOINT ovos-stt-server --engine {PLUGIN_HERE}
 ```
 
 build it


### PR DESCRIPTION
The right endpoint script is `ovos-stt-server`

https://github.com/OpenVoiceOS/ovos-stt-http-server/blob/dev/setup.py#L81

`ovos-stt-http-server` does not work