### PR TITLE
feat/lang_detection_plugin

### DIFF
--- a/.github/workflows/publish_alpha.yml
+++ b/.github/workflows/publish_alpha.yml
@@ -13,7 +13,7 @@ on:
       - 'LICENSE'
       - 'CHANGELOG.md'
       - 'MANIFEST.in'
-      - 'readme.md'
+      - 'README.md'
       - 'scripts/**'
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -30,20 +30,25 @@ ovos-stt-server --help
 usage: ovos-stt-server [-h] [--engine ENGINE] [--port PORT] [--host HOST]
 
 options:
-  -h, --help                  show this help message and exit
-  --engine ENGINE             stt plugin to be used
-  --port PORT                 port number
-  --host HOST                 host
-  --lang LANG                 default language
-  --gradio                    flag to enable Gradio web UI
-  --cache                     flag to pre-cache examples in Gradio web UI
-  --title TITLE               title for Gradio UI
-  --description DESCRIPTION   Description for Gradio UI
-  --info INFO                 Text to display in Gradio UI
-  --badge BADGE               URL of badge to show in Gradio UI
+  -h, --help            show this help message and exit
+  --engine ENGINE       stt plugin to be used
+  --lang-engine LANG_ENGINE
+                        audio language detection plugin to be used (optional)
+  --port PORT           port number
+  --host HOST           host
+  --lang LANG           default language supported by plugin (default comes from mycroft.conf)
+  --multi               Load a plugin instance per language (force lang support, loads multiple plugins into memory)
+  --gradio              Enable Gradio Web UI
+  --cache               Cache models for Gradio demo
+  --title TITLE         Title for webUI
+  --description DESCRIPTION
+                        Text description to print in UI
+  --info INFO           Text to display at end of UI
+  --badge BADGE         URL of visitor badge
 ```
 > Note: `ffmpeg` is required for Gradio
 
+eg `ovos-stt-server --engine ovos-stt-plugin-fasterwhisper --lang-engine ovos-audio-transformer-plugin-fasterwhisper`
 
 ## Docker
 

--- a/ovos_stt_http_server/__init__.py
+++ b/ovos_stt_http_server/__init__.py
@@ -13,76 +13,78 @@
 from tempfile import NamedTemporaryFile
 
 from fastapi import FastAPI
+from ovos_config import Configuration
+from ovos_plugin_manager.audio_transformers import load_audio_transformer_plugin, AudioLanguageDetector
 from ovos_plugin_manager.stt import load_stt_plugin
 from ovos_utils.log import LOG
-from speech_recognition import Recognizer, AudioFile, AudioData
+from speech_recognition import AudioData
 from starlette.requests import Request
-
 
 LOG.set_level("ERROR")  # avoid server side logs
 
 
 class ModelContainer:
-    def __init__(self, plugin: str, config: dict=None):
-        self.plugin = load_stt_plugin(plugin)
-        if not self.plugin:
+    def __init__(self, plugin: str, lang_plugin: str = None, config: dict = None):
+        plugin = load_stt_plugin(plugin)
+        self.lang_plugin = None
+        if not plugin:
             raise ValueError(f"Failed to load STT: {plugin}")
+        if lang_plugin:
+            lang_plugin = load_audio_transformer_plugin(lang_plugin)
+            if not lang_plugin:
+                raise ValueError(f"Failed to load lang detection plugin: {plugin}")
+            assert issubclass(lang_plugin, AudioLanguageDetector)
+            LOG.info(f"Loading Audio Language detector plugin: {lang_plugin}")
+            self.lang_plugin = lang_plugin()
+        LOG.info(f"Loading STT plugin: {plugin}")
+        self.engine = plugin(config)
+
+    def process_audio(self, audio: AudioData, lang: str = "auto"):
+        if lang == "auto":
+            lang, prob = self.lang_plugin.detect(audio)
+        return self.engine.execute(audio, language=lang) or ""
+
+
+class MultiModelContainer:
+    """ loads 1 model per language """
+
+    def __init__(self, plugin: str, lang_plugin: str = None, config: dict = None):
+        self.plugin_class = load_stt_plugin(plugin)
+        self.lang_plugin = None
+        if not self.plugin_class:
+            raise ValueError(f"Failed to load STT: {plugin}")
+        if lang_plugin:
+            lang_plugin = load_audio_transformer_plugin(lang_plugin)
+            if not lang_plugin:
+                raise ValueError(f"Failed to load lang detection plugin: {plugin}")
+            assert issubclass(lang_plugin, AudioLanguageDetector)
+            self.lang_plugin = lang_plugin()
         self.engines = {}
-        self.data = {}
         self.config = config or {}
 
-    def get_engine(self, session_id):
-        if session_id not in self.engines:
-            self.load_engine(session_id)
-        return self.engines[session_id]
+    def get_engine(self, lang: str):
+        if lang not in self.engines:
+            self.load_engine(lang)
+        return self.engines[lang]
 
-    def load_engine(self, session_id, config=None):
+    def load_engine(self, lang: str, config=None):
+        # might need to load multiple models per language
         config = config or self.config
-        self.engines[session_id] = self.plugin(config=config)
+        config["lang"] = lang
+        self.engines[lang] = self.plugin_class(config=config)
 
-    def unload_engine(self, session_id):
-        if session_id in self.engines:
-            self.engines.pop(session_id)
-        if session_id in self.data:
-            self.data.pop(session_id)
+    def unload_engine(self, lang: str):
+        if lang in self.engines:
+            self.engines.pop(lang)
 
-    def process_audio(self, audio: AudioData, lang, session_id=None):
-        session_id = session_id or lang  # shared model for non-streaming stt
-        engine = self.get_engine(session_id)
-        if audio or engine.can_stream:
-            return engine.execute(audio, language=lang) or ""
-        return ""
-
-    def stream_start(self, session_id):
-        engine = self.get_engine(session_id)
-        if engine.can_stream:
-            engine.stream_start()
-
-    def stream_data(self, audio, session_id):
-        engine = self.get_engine(session_id)
-        if engine.can_stream:
-            # streaming plugin in server + streaming plugin in core
-            return engine.stream_data(audio)
-        else:
-            # non streaming plugin in server + streaming plugin in core
-            if session_id not in self.data:
-                self.data[session_id] = b""
-            self.data[session_id] += audio
-        return ""
-
-    def stream_stop(self, session_id):
-        engine = self.get_engine(session_id)
-        if engine.can_stream:
-            transcript = engine.stream_stop()
-        else:
-            audio = AudioData(self.data[session_id],
-                              sample_rate=16000, sample_width=2)
-            transcript = engine.execute(audio)
-        self.unload_engine(session_id)
-        return transcript or ""
+    def process_audio(self, audio: AudioData, lang: str):
+        if lang == "auto":
+            lang, prob = self.lang_plugin.detect(audio.get_wav_data())
+        engine = self.get_engine(lang)
+        return engine.execute(audio, language=lang) or ""
 
 
-def bytes2audiodata(data):
+def bytes2audiodata(data: bytes) -> AudioData:
     recognizer = Recognizer()
     with NamedTemporaryFile() as fp:
         fp.write(data)
@@ -91,52 +93,39 @@ def bytes2audiodata(data):
     return audio
 
 
-def create_app(stt_plugin, has_gradio=False):
+def create_app(stt_plugin, lang_plugin=None, multi=False, has_gradio=False):
     app = FastAPI()
-    model = ModelContainer(stt_plugin)
+    if multi:
+        model = MultiModelContainer(stt_plugin, lang_plugin)
+    else:
+        model = ModelContainer(stt_plugin, lang_plugin)
 
     @app.get("/status")
     def stats(request: Request):
         return {"status": "ok",
                 "plugin": stt_plugin,
+                "lang_plugin": lang_plugin,
                 "gradio": has_gradio}
 
     @app.post("/stt")
     async def get_stt(request: Request):
-        lang = str(request.query_params.get("lang", "en-us")).lower()
+        lang = str(request.query_params.get("lang", Configuration().get("lang", "en-us"))).lower()
         audio_bytes = await request.body()
         audio = bytes2audiodata(audio_bytes)
         return model.process_audio(audio, lang)
 
-    @app.post("/stream/start")
-    def stream_start(request: Request):
-        lang = str(request.query_params.get("lang", "en-us")).lower()
-        uuid = str(request.query_params.get("uuid") or lang)
-        model.load_engine(uuid, {"lang": lang})
-        model.stream_start(uuid)
-        return {"status": "ok", "uuid": uuid, "lang": lang}
-
-    @app.post("/stream/audio")
-    async def stream(request: Request):
-        audio = await request.body()
-        lang = str(request.query_params.get("lang", "en-us")).lower()
-        uuid = str(request.query_params.get("uuid") or lang)
-        transcript = model.stream_data(audio, uuid)
-        return {"status": "ok", "uuid": uuid,
-                "lang": lang, "transcript": transcript}
-
-    @app.post("/stream/end")
-    def stream_end(request: Request):
-        lang = str(request.query_params.get("lang", "en-us")).lower()
-        uuid = str(request.query_params.get("uuid") or lang)
-        # model.wait_until_done(uuid)
-        transcript = model.stream_stop(uuid)
-        return {"status": "ok", "uuid": uuid,
-                "lang": lang, "transcript": transcript}
+    @app.post("/lang_detect")
+    async def get_lang(request: Request):
+        audio_bytes = await request.body()
+        lang, prob = model.lang_plugin.detect(audio_bytes)
+        return {"lang": lang, "conf": prob}
 
     return app, model
 
 
-def start_stt_server(engine: str, has_gradio: bool = False) -> (FastAPI, ModelContainer):
-    app, engine = create_app(engine, has_gradio)
+def start_stt_server(engine: str,
+                     lang_engine: str = None,
+                     multi: bool = False,
+                     has_gradio: bool = False) -> (FastAPI, ModelContainer):
+    app, engine = create_app(engine, lang_engine, multi, has_gradio)
     return app, engine

--- a/ovos_stt_http_server/__init__.py
+++ b/ovos_stt_http_server/__init__.py
@@ -21,7 +21,7 @@ from ovos_utils.log import LOG
 from speech_recognition import AudioData, Recognizer, AudioFile
 from starlette.requests import Request
 
-#LOG.set_level("ERROR")  # avoid server side logs
+LOG.set_level("ERROR")  # avoid server side logs
 
 
 class ModelContainer:
@@ -33,7 +33,7 @@ class ModelContainer:
         if lang_plugin:
             lang_plugin = load_audio_transformer_plugin(lang_plugin)
             if not lang_plugin:
-                raise ValueError(f"Failed to load lang detection plugin: {plugin}")
+                raise ValueError(f"Failed to load lang detection plugin: {lang_plugin}")
             assert issubclass(lang_plugin, AudioLanguageDetector)
             LOG.info(f"Loading Audio Language detector plugin: {lang_plugin}")
             self.lang_plugin = lang_plugin()
@@ -62,7 +62,7 @@ class MultiModelContainer:
         if lang_plugin:
             lang_plugin = load_audio_transformer_plugin(lang_plugin)
             if not lang_plugin:
-                raise ValueError(f"Failed to load lang detection plugin: {plugin}")
+                raise ValueError(f"Failed to load lang detection plugin: {lang_plugin}")
             assert issubclass(lang_plugin, AudioLanguageDetector)
             self.lang_plugin = lang_plugin()
         self.engines = {}

--- a/ovos_stt_http_server/__main__.py
+++ b/ovos_stt_http_server/__main__.py
@@ -11,20 +11,25 @@
 # limitations under the License.
 #
 import argparse
+
 import uvicorn
+from ovos_config import Configuration
 from ovos_utils.log import LOG
 
-from ovos_stt_http_server.gradio_app import bind_gradio_service
 from ovos_stt_http_server import start_stt_server
+from ovos_stt_http_server.gradio_app import bind_gradio_service
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--engine", help="stt plugin to be used", required=True)
+    parser.add_argument("--lang-engine", help="audio language detection plugin to be used")
     parser.add_argument("--port", help="port number", default=8080)
     parser.add_argument("--host", help="host", default="0.0.0.0")
     parser.add_argument("--lang", help="default language supported by plugin",
-                        default="en-us")
+                        default=Configuration().get("lang", "en-us"))
+    parser.add_argument("--multi", help="Load a plugin instance per language (force lang support)",
+                        action="store_true")
     parser.add_argument("--gradio", help="Enable Gradio Web UI",
                         action="store_true")
     parser.add_argument("--cache", help="Cache models for Gradio demo",
@@ -38,7 +43,9 @@ def main():
     parser.add_argument("--badge", help="URL of visitor badge", default=None)
     args = parser.parse_args()
 
-    server, engine = start_stt_server(args.engine, has_gradio=bool(args.gradio))
+    server, engine = start_stt_server(args.engine, lang_engine=args.lang_engine,
+                                      multi=bool(args.multi),
+                                      has_gradio=bool(args.gradio))
     LOG.info("Server Started")
     if args.gradio:
         bind_gradio_service(server, engine, args.title, args.description,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ovos-plugin-manager>=0.0.26,<1.0.0
+ovos-plugin-manager>=0.7.0,<1.0.0
 fastapi~=0.95
 uvicorn~=0.22
 gradio~=3.28

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ovos-plugin-manager>=0.0.18,<1.0.0
+ovos-plugin-manager>=0.0.26,<1.0.0
 fastapi~=0.95
 uvicorn~=0.22
 gradio~=3.28

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def required(requirements_file):
                 if pkg.strip() and not pkg.startswith("#")]
 
 
-with open(path.join(BASE_PATH, "readme.md"), "r") as f:
+with open(path.join(BASE_PATH, "README.md"), "r") as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
- remove unfinished streaming stt implementation
- put the multi model loader behind a --multi flag, assume plugins are multilingual unless told otherwise
- add lang detection plugin
- lang detection endpoint
- if lang == "auto" in the stt request, detection is performed before STT

needs https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new command-line options for `ovos-stt-server`, including `--lang-engine` for audio language detection and `--multi` for multi-language plugin instances.
  - New `/lang_detect` endpoint for language detection.

- **Improvements**
  - Enhanced clarity of existing command-line options.
  - Updated default language settings in the command-line interface.
  - Corrected filename references to ensure workflows and setup scripts operate correctly.

- **Dependency Updates**
  - Updated version specification for `ovos-plugin-manager` in the requirements. 

- **Bug Fixes**
  - Corrected file references to ensure workflows and setup scripts operate correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->