### PR TITLE
fix: remove quotes from the start and end of transcribed text

### DIFF
--- a/ovos_stt_http_server/__init__.py
+++ b/ovos_stt_http_server/__init__.py
@@ -13,6 +13,7 @@
 from tempfile import NamedTemporaryFile
 
 from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
 from ovos_plugin_manager.stt import load_stt_plugin
 from ovos_utils.log import LOG
 from speech_recognition import Recognizer, AudioFile, AudioData
@@ -101,7 +102,7 @@ def create_app(stt_plugin, has_gradio=False):
                 "plugin": stt_plugin,
                 "gradio": has_gradio}
 
-    @app.post("/stt")
+    @app.post("/stt", response_class=PlainTextResponse)
     async def get_stt(request: Request):
         lang = str(request.query_params.get("lang", "en-us")).lower()
         audio_bytes = await request.body()


### PR DESCRIPTION
FastAPI by default returns json responses but the `stt` endpoint is used as a plaintext response in the helper plugin, so I added `response_class=PlainTextResponse` to the endpoint. The quotes caused some utterances to not be interpreted correctly.

An alternative would be handling this different in the companion plugin [here](https://github.com/OpenVoiceOS/ovos-stt-plugin-server/blob/b9415a8601e82a96bb82996d4024431d76de2ec8/ovos_stt_plugin_server/__init__.py#L54), but I don't think that would be better because the companion plugin could be used for different servers that don't return JSON.