### PR TITLE
fix:int port

### DIFF
--- a/ovos_stt_http_server/__main__.py
+++ b/ovos_stt_http_server/__main__.py
@@ -51,7 +51,7 @@ def main():
         bind_gradio_service(server, engine, args.title, args.description,
                             args.info, args.badge, args.lang, args.cache)
         LOG.info("Gradio Started")
-    uvicorn.run(server, host=args.host, port=args.port)
+    uvicorn.run(server, host=args.host, port=int(args.port))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.13/logging/__init__.py", line 1150, in emit
    msg = self.format(record)
  File "/usr/lib/python3.13/logging/__init__.py", line 998, in format
    return fmt.format(record)
           ~~~~~~~~~~^^^^^^^^
  File "/usr/lib/python3.13/logging/__init__.py", line 711, in format
    record.message = record.getMessage()
                     ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/logging/__init__.py", line 400, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: %d format: a real number is required, not str

```