### PR TITLE
Fix invalid reference in `gradio_app`

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -9,4 +9,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(tqdm|bs4|gradio|bitstruct|attrs).*'
+      packages-exclude: '^(tqdm|bs4|gradio|bitstruct|attrs|referencing).*'

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -9,4 +9,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(tqdm|bs4|gradio|bitstruct).*'
+      packages-exclude: '^(tqdm|bs4|gradio|bitstruct|attrs).*'

--- a/ovos_stt_http_server/gradio_app.py
+++ b/ovos_stt_http_server/gradio_app.py
@@ -23,7 +23,7 @@ def bind_gradio_service(app, stt_engine: ModelContainer,
                         default_lang="en", cache=True):
     global STT
     STT = stt_engine
-    languages = list(stt_engine.plugin().available_languages or [default_lang])
+    languages = list(stt_engine.engine.available_languages or [default_lang])
     languages.sort()
     LOG.debug(languages)
 


### PR DESCRIPTION
Fix bad reference in `gradio_app` introduced in v0.0.3
Validated with [a Nemo container build](https://nemo.neonaialpha.com/gradio/)
Includes an update to license tests to resolve failing action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined automated checks to optimize package management during testing.

- **Bug Fixes**
  - Improved the retrieval of available language options in the interactive service for a more reliable selection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->