### PR TITLE
docs: voice-pihole hub — /docs index + centralised nginx recipes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,53 +24,62 @@ when it doesn't need to pretend to be someone else.
 ## Compat coverage matrix
 
 Each row is one compat surface — one router (or process-side bridge) plus
-its docs, examples, and live tests. The **PR** column links to the
-in-flight PR; once a row's PR is merged, the per-vendor docs live inline
-in [`api-compatibility.md`](api-compatibility.md).
+its docs, examples, and live tests. **Status legend:**
+
+- ✅ **merged** — landed on `dev`; full per-vendor docs live inline in
+  [`api-compatibility.md`](api-compatibility.md).
+- 🟡 **open** — PR is up; full per-vendor docs live on the feature branch
+  until merge.
+- ⚪ **planned** — see the [TODO / WIP](#todo--wip) section below.
 
 ### Foundation
 
 | Branch | Status | PR |
 | :--- | :--- | :--- |
-| `modernize-base` — gradio drop, CORSMiddleware, audio_utils, shared workflows, unit test scaffolding (≥90% coverage) | shipped | [#52](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/52) |
-| `docs/voice-pihole-hub` — this hub itself | shipped | [#70](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/70) |
+| `modernize-base` — gradio drop, CORSMiddleware, audio_utils, shared workflows, unit test scaffolding (≥90% coverage) | ✅ merged | [#52](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/52) |
+| `docs/voice-pihole-hub` — this hub itself | 🟡 open | [#70](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/70) |
 
 ### Commercial cloud STT
 
 | Vendor | Prefix(es) | Status | PR |
 | :--- | :--- | :--- | :--- |
-| OpenAI Whisper | `/openai/v1/audio/*` | shipped | [#53](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/53) |
-| Deepgram | `/deepgram/v1/listen` (HTTP + WS) | shipped | [#54](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/54) |
-| Google Cloud STT | `/google/v1/speech:recognize` | shipped | [#55](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/55) |
-| AssemblyAI | `/assemblyai/v2/{upload,transcript,realtime/ws}` | shipped | [#56](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/56) |
-| Speechmatics | `/speechmatics/v1/{jobs*, ""}` (REST + WS) | shipped | [#57](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/57) |
-| Microsoft Azure Speech | `/azure-stt/cognitiveservices/v1` (REST + WS) | shipped | [#58](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/58) |
-| AWS Transcribe | `/aws/transcribe` (batch + streaming WS) | shipped | [#60](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/60) |
-| IBM Watson STT | `/watson/speech-to-text/v1/recognize` (REST + WS) | shipped | [#61](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/61) |
-| Wit.ai (Meta) | `/wit/speech` | shipped | [#62](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/62) |
-| Chromium Web Speech | `/speech-api/v2/recognize` | shipped | [#68](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/68) |
+| OpenAI Whisper | `/openai/v1/audio/*` | 🟡 open | [#53](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/53) |
+| Deepgram | `/deepgram/v1/listen` (HTTP + WS) | 🟡 open | [#54](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/54) |
+| Google Cloud STT | `/google/v1/speech:recognize` | 🟡 open | [#55](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/55) |
+| AssemblyAI | `/assemblyai/v2/{upload,transcript,realtime/ws}` | 🟡 open | [#56](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/56) |
+| Speechmatics | `/speechmatics/v1/{jobs*, ""}` (REST + WS) | 🟡 open | [#57](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/57) |
+| Microsoft Azure Speech | `/azure-stt/cognitiveservices/v1` (REST + WS) | 🟡 open | [#58](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/58) |
+| AWS Transcribe | `/aws/transcribe` (batch + streaming WS) | 🟡 open | [#60](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/60) |
+| IBM Watson STT | `/watson/speech-to-text/v1/recognize` (REST + WS) | 🟡 open | [#61](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/61) |
+| Wit.ai (Meta) | `/wit/speech` | 🟡 open | [#62](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/62) |
+| Chromium Web Speech | `/speech-api/v2/recognize` | 🟡 open | [#68](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/68) |
 
 ### Self-hosted / open-source server protocols
 
 | Server | Prefix / surface | Status | PR |
 | :--- | :--- | :--- | :--- |
-| vosk-server (WebSocket) | `/vosk` | shipped | [#63](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/63) |
-| vosk-server (gRPC) | `--vosk-grpc-port` opt-in | shipped | [#65](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/65) |
-| vosk-server (WebRTC) | `/vosk-webrtc/offer` (opt-in extra) | shipped | [#66](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/66) |
-| vosk-server (MQTT) | `--vosk-mqtt-broker` opt-in | shipped | [#67](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/67) |
-| kaldi-gstreamer-server | `/client/ws/speech` + `/client/dynamic/recognize` | shipped | [#69](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/69) |
-| whisper.cpp HTTP server | `/whisper-cpp/inference` | shipped | [#64](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/64) |
-| faster-whisper-server | re-uses `/openai/v1` | docs only | [#72](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/72) |
-| Wyoming (HA) | external adapter — see [wyoming-integration.md](wyoming-integration.md) | adapter only | [#59](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/59) |
+| vosk-server (WebSocket) | `/vosk` | 🟡 open | [#63](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/63) |
+| vosk-server (gRPC) | `--vosk-grpc-port` opt-in | 🟡 open | [#65](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/65) |
+| vosk-server (WebRTC) | `/vosk-webrtc/offer` (opt-in extra) | 🟡 open | [#66](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/66) |
+| vosk-server (MQTT) | `--vosk-mqtt-broker` opt-in | 🟡 open | [#67](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/67) |
+| kaldi-gstreamer-server | `/client/ws/speech` + `/client/dynamic/recognize` | 🟡 open | [#69](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/69) |
+| whisper.cpp HTTP server | `/whisper-cpp/inference` | 🟡 open | [#64](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/64) |
+| faster-whisper-server | re-uses `/openai/v1` | 🟡 open (docs only) | [#72](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/72) |
+| Wyoming (HA) | external adapter — see [wyoming-integration.md](wyoming-integration.md) | ✅ merged (adapter docs) | [#59](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/59) |
 
 ### OpenAI-shape Whisper hosts (Tier 2 — no router code)
 
 | Host | Status | PR |
 | :--- | :--- | :--- |
-| Groq, Cloudflare Workers AI, Fireworks AI, Together AI, OpenRouter | docs only | [#71](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/71) |
+| Groq, Cloudflare Workers AI, Fireworks AI, Together AI, OpenRouter | 🟡 open (docs only) | [#71](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/71) |
 
 Apps targeting these hosts already speak the OpenAI `/v1/audio/transcriptions`
 contract — point them at our `/openai/v1` prefix.
+
+> :information_source: Status is updated on PR merge. Until a PR lands,
+> its per-vendor docs section lives on the feature branch — click the PR
+> link to read it. The status here reflects merge-into-`dev`, not local
+> implementation completeness.
 
 ## Voice-pihole concept
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,71 @@
+# `ovos-stt-http-server` Documentation Hub
+
+`ovos-stt-http-server` exposes any OVOS STT plugin as a network service. On
+its own it speaks one native protocol — but with compat routers enabled it
+also pretends to be every major cloud STT API and every popular
+self-hosted server, so **unmodified consumer apps transparently land on
+this box** instead of a third-party cloud.
+
+This directory is the documentation hub. Start with the use-case guide
+that matches your goal:
+
+| Goal | Read |
+| :--- | :--- |
+| Make unmodified consumer apps stop calling cloud STT services | [voice-pihole.md](voice-pihole.md) |
+| Drive this server with the official Python/Node SDK of a specific vendor | [api-compatibility.md](api-compatibility.md) |
+| Replace an existing self-hosted STT server on the wire | [api-compatibility.md](api-compatibility.md) (per-server section) |
+| Bridge Home Assistant Voice / Voice PE | [wyoming-integration.md](wyoming-integration.md) |
+| Understand the audio format negotiation | [audio-formats.md](audio-formats.md) |
+
+The remaining files (`index.md`, etc.) cover the native `/stt` and
+`/lang_detect` endpoints — what every other consumer of this server uses
+when it doesn't need to pretend to be someone else.
+
+## Compat coverage matrix
+
+Each row is one compat surface — one router (or process-side bridge) plus
+its docs, examples, and live tests.
+
+### Commercial cloud STT
+
+| Vendor | Prefix(es) | Status |
+| :--- | :--- | :--- |
+| OpenAI Whisper | `/openai/v1/audio/*` | shipped |
+| OpenAI Whisper translation | `/openai/v1/audio/translations` | shipped (via OVOS translate plugin) |
+| Deepgram | `/deepgram/v1/listen` (HTTP + WS) | shipped |
+| Google Cloud STT | `/google/v1/speech:recognize` | shipped |
+| AssemblyAI | `/assemblyai/v2/{upload,transcript,realtime/ws}` | shipped |
+| Speechmatics | `/speechmatics/v1/{jobs*, ""}` (REST + WS) | shipped |
+| Microsoft Azure Speech | `/azure-stt/cognitiveservices/v1` (REST + WS) | shipped |
+| AWS Transcribe | `/aws/transcribe` (batch + streaming WS) | shipped |
+| IBM Watson STT | `/watson/speech-to-text/v1/recognize` (REST + WS) | shipped |
+| Wit.ai (Meta) | `/wit/speech` | shipped |
+| Chromium Web Speech | `/speech-api/v2/recognize` | shipped |
+
+### Self-hosted / open-source server protocols
+
+| Server | Prefix / surface | Status |
+| :--- | :--- | :--- |
+| vosk-server (WebSocket) | `/vosk` | shipped |
+| vosk-server (gRPC) | `--vosk-grpc-port` opt-in | shipped |
+| vosk-server (WebRTC) | `/vosk-webrtc/offer` (opt-in extra) | shipped |
+| vosk-server (MQTT) | `--vosk-mqtt-broker` opt-in | shipped |
+| kaldi-gstreamer-server | `/client/ws/speech` + `/client/dynamic/recognize` | shipped |
+| whisper.cpp HTTP server | `/whisper-cpp/inference` | shipped |
+| faster-whisper-server | (re-uses `/openai/v1`) | docs-only |
+| Wyoming (HA) | external adapter — see [wyoming-integration.md](wyoming-integration.md) | adapter only |
+
+### OpenAI-shape Whisper hosts (no new code needed)
+
+Apps that target Groq/Cloudflare/Fireworks/Together/OpenRouter all use the
+OpenAI `/v1/audio/transcriptions` contract. Point them at our `/openai/v1`
+prefix and they work — see [api-compatibility.md](api-compatibility.md) for
+per-host nginx blocks.
+
+## Voice-pihole concept
+
+A single document — [voice-pihole.md](voice-pihole.md) — collects every
+DNS-rewrite + nginx-reverse-proxy + CA-trust recipe across all the above
+vendors. Use it when you want unmodified consumer apps to transparently
+hit this server without any client-side configuration. The per-vendor
+sections in `api-compatibility.md` reference back into it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,48 +24,120 @@ when it doesn't need to pretend to be someone else.
 ## Compat coverage matrix
 
 Each row is one compat surface — one router (or process-side bridge) plus
-its docs, examples, and live tests.
+its docs, examples, and live tests. The **PR** column links to the
+in-flight PR; once a row's PR is merged, the per-vendor docs live inline
+in [`api-compatibility.md`](api-compatibility.md).
+
+### Foundation
+
+| Branch | Status | PR |
+| :--- | :--- | :--- |
+| `modernize-base` — gradio drop, CORSMiddleware, audio_utils, shared workflows, unit test scaffolding (≥90% coverage) | shipped | [#52](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/52) |
+| `docs/voice-pihole-hub` — this hub itself | shipped | [#70](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/70) |
 
 ### Commercial cloud STT
 
-| Vendor | Prefix(es) | Status |
-| :--- | :--- | :--- |
-| OpenAI Whisper | `/openai/v1/audio/*` | shipped |
-| OpenAI Whisper translation | `/openai/v1/audio/translations` | shipped (via OVOS translate plugin) |
-| Deepgram | `/deepgram/v1/listen` (HTTP + WS) | shipped |
-| Google Cloud STT | `/google/v1/speech:recognize` | shipped |
-| AssemblyAI | `/assemblyai/v2/{upload,transcript,realtime/ws}` | shipped |
-| Speechmatics | `/speechmatics/v1/{jobs*, ""}` (REST + WS) | shipped |
-| Microsoft Azure Speech | `/azure-stt/cognitiveservices/v1` (REST + WS) | shipped |
-| AWS Transcribe | `/aws/transcribe` (batch + streaming WS) | shipped |
-| IBM Watson STT | `/watson/speech-to-text/v1/recognize` (REST + WS) | shipped |
-| Wit.ai (Meta) | `/wit/speech` | shipped |
-| Chromium Web Speech | `/speech-api/v2/recognize` | shipped |
+| Vendor | Prefix(es) | Status | PR |
+| :--- | :--- | :--- | :--- |
+| OpenAI Whisper | `/openai/v1/audio/*` | shipped | [#53](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/53) |
+| Deepgram | `/deepgram/v1/listen` (HTTP + WS) | shipped | [#54](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/54) |
+| Google Cloud STT | `/google/v1/speech:recognize` | shipped | [#55](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/55) |
+| AssemblyAI | `/assemblyai/v2/{upload,transcript,realtime/ws}` | shipped | [#56](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/56) |
+| Speechmatics | `/speechmatics/v1/{jobs*, ""}` (REST + WS) | shipped | [#57](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/57) |
+| Microsoft Azure Speech | `/azure-stt/cognitiveservices/v1` (REST + WS) | shipped | [#58](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/58) |
+| AWS Transcribe | `/aws/transcribe` (batch + streaming WS) | shipped | [#60](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/60) |
+| IBM Watson STT | `/watson/speech-to-text/v1/recognize` (REST + WS) | shipped | [#61](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/61) |
+| Wit.ai (Meta) | `/wit/speech` | shipped | [#62](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/62) |
+| Chromium Web Speech | `/speech-api/v2/recognize` | shipped | [#68](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/68) |
 
 ### Self-hosted / open-source server protocols
 
-| Server | Prefix / surface | Status |
+| Server | Prefix / surface | Status | PR |
+| :--- | :--- | :--- | :--- |
+| vosk-server (WebSocket) | `/vosk` | shipped | [#63](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/63) |
+| vosk-server (gRPC) | `--vosk-grpc-port` opt-in | shipped | [#65](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/65) |
+| vosk-server (WebRTC) | `/vosk-webrtc/offer` (opt-in extra) | shipped | [#66](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/66) |
+| vosk-server (MQTT) | `--vosk-mqtt-broker` opt-in | shipped | [#67](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/67) |
+| kaldi-gstreamer-server | `/client/ws/speech` + `/client/dynamic/recognize` | shipped | [#69](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/69) |
+| whisper.cpp HTTP server | `/whisper-cpp/inference` | shipped | [#64](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/64) |
+| faster-whisper-server | re-uses `/openai/v1` | docs only | [#72](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/72) |
+| Wyoming (HA) | external adapter — see [wyoming-integration.md](wyoming-integration.md) | adapter only | [#59](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/59) |
+
+### OpenAI-shape Whisper hosts (Tier 2 — no router code)
+
+| Host | Status | PR |
 | :--- | :--- | :--- |
-| vosk-server (WebSocket) | `/vosk` | shipped |
-| vosk-server (gRPC) | `--vosk-grpc-port` opt-in | shipped |
-| vosk-server (WebRTC) | `/vosk-webrtc/offer` (opt-in extra) | shipped |
-| vosk-server (MQTT) | `--vosk-mqtt-broker` opt-in | shipped |
-| kaldi-gstreamer-server | `/client/ws/speech` + `/client/dynamic/recognize` | shipped |
-| whisper.cpp HTTP server | `/whisper-cpp/inference` | shipped |
-| faster-whisper-server | (re-uses `/openai/v1`) | docs-only |
-| Wyoming (HA) | external adapter — see [wyoming-integration.md](wyoming-integration.md) | adapter only |
+| Groq, Cloudflare Workers AI, Fireworks AI, Together AI, OpenRouter | docs only | [#71](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/71) |
 
-### OpenAI-shape Whisper hosts (no new code needed)
-
-Apps that target Groq/Cloudflare/Fireworks/Together/OpenRouter all use the
-OpenAI `/v1/audio/transcriptions` contract. Point them at our `/openai/v1`
-prefix and they work — see [api-compatibility.md](api-compatibility.md) for
-per-host nginx blocks.
+Apps targeting these hosts already speak the OpenAI `/v1/audio/transcriptions`
+contract — point them at our `/openai/v1` prefix.
 
 ## Voice-pihole concept
 
-A single document — [voice-pihole.md](voice-pihole.md) — collects every
-DNS-rewrite + nginx-reverse-proxy + CA-trust recipe across all the above
-vendors. Use it when you want unmodified consumer apps to transparently
-hit this server without any client-side configuration. The per-vendor
-sections in `api-compatibility.md` reference back into it.
+[voice-pihole.md](voice-pihole.md) collects every DNS-rewrite +
+nginx-reverse-proxy + CA-trust recipe across all the above vendors. Use
+it when you want unmodified consumer apps to transparently hit this
+server without any client-side configuration. The per-vendor sections in
+`api-compatibility.md` reference back into it.
+
+---
+
+## TODO / WIP
+
+Things explicitly **not** done yet — open issues / PRs welcome.
+
+### Streaming partial transcripts
+
+Every compat router that exposes a streaming surface (Deepgram WS,
+AssemblyAI realtime, Speechmatics RT, Azure WS, Watson WS, vosk WS,
+AWS streaming, Chromium) currently runs as **buffered batch**: audio is
+collected for the lifetime of the stream and a single final transcript is
+emitted on close / EOS. This is because OVOS STT plugins themselves are
+batch-only — they don't expose a partial / interim hypothesis interface.
+
+To produce true interim transcripts we'd need:
+
+- A VAD-driven chunker upstream of the OVOS plugin call, OR
+- New plugin-side support for streaming recognition (an OPM contract change)
+
+Tracking issue: TBD.
+
+### Vendor coverage gaps
+
+- **Web Speech API native protocol** — the binary `Sec-WebSocket-Protocol`
+  framing that modern Chrome/Edge use for the in-browser `SpeechRecognition`
+  Web API (distinct from the legacy `/speech-api/v2/recognize` REST that
+  PR #68 covers). Reverse-engineering needed.
+- **Rev.ai** — REST + streaming WS. Lower priority than the Tier-1 vendors
+  but apps in the media-transcription space use it.
+- **Soniox** — gRPC streaming. Niche but real.
+- **AssemblyAI streaming V3** — schema differs from the V2 realtime we
+  ship (PR #56). Add when V2 sunsets.
+- **Whisper.cpp's verbose-json with segments** — accepted today but
+  segment-level timestamps require a VAD pipeline OVOS plugins don't
+  expose. Tracked as part of "Streaming partial transcripts" above.
+- **AWS Transcribe streaming over real HTTP/2 event-stream** — we expose
+  a plain WS surface (PR #60) for ease of integration; the real upstream
+  uses AWS event-stream framing over HTTP/2. SDK-level apps that bypass
+  the WS path need a separate translator.
+- **Vosk gRPC `StatsService`** — `vosk-server`'s second proto service
+  (n_streams / n_total_streams / RTF) is not implemented (PR #65 ships
+  only `SttService.StreamingRecognize`).
+
+### Documentation TODOs
+
+- One-pager per use-case ("running on a Raspberry Pi", "behind Tailscale",
+  "with Caddy instead of nginx") — voice-pihole.md is nginx-centric today.
+- A canonical mkcert / step-ca walkthrough for new self-hosters.
+- A migration guide from each vendor SDK to drop-in mode (per-vendor
+  config diff).
+
+### Process
+
+Once PR #70 (this hub) lands, every open compat PR rebases on `dev` and
+in its own diff:
+1. Removes its row's PR link from the master index in `api-compatibility.md`.
+2. Inlines its full docs section below the index.
+
+That converts each row from "in-flight" to "shipped + officialised". The
+TODO list above gets pruned as items land.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,48 +6,36 @@ also pretends to be every major cloud STT API and every popular
 self-hosted server, so **unmodified consumer apps transparently land on
 this box** instead of a third-party cloud.
 
-This directory is the documentation hub. Start with the use-case guide
-that matches your goal:
-
 | Goal | Read |
 | :--- | :--- |
 | Make unmodified consumer apps stop calling cloud STT services | [voice-pihole.md](voice-pihole.md) |
 | Drive this server with the official Python/Node SDK of a specific vendor | [api-compatibility.md](api-compatibility.md) |
-| Replace an existing self-hosted STT server on the wire | [api-compatibility.md](api-compatibility.md) (per-server section) |
+| Replace an existing self-hosted STT server on the wire | [api-compatibility.md](api-compatibility.md) |
 | Bridge Home Assistant Voice / Voice PE | [wyoming-integration.md](wyoming-integration.md) |
-| Understand the audio format negotiation | [audio-formats.md](audio-formats.md) |
-
-The remaining files (`index.md`, etc.) cover the native `/stt` and
-`/lang_detect` endpoints — what every other consumer of this server uses
-when it doesn't need to pretend to be someone else.
+| Audio format negotiation | [audio-formats.md](audio-formats.md) |
 
 ## Compat coverage matrix
 
-Each row is one compat surface — one router (or process-side bridge) plus
-its docs, examples, and live tests. **Status legend:**
-
-- ✅ **merged** — landed on `dev`; full per-vendor docs live inline in
-  [`api-compatibility.md`](api-compatibility.md).
-- 🟡 **open** — PR is up; full per-vendor docs live on the feature branch
-  until merge.
-- ⚪ **planned** — see the [TODO / WIP](#todo--wip) section below.
+- ✅ **merged** — landed on `dev`; per-vendor docs inlined in [`api-compatibility.md`](api-compatibility.md).
+- 🟡 **open** — PR up; per-vendor docs on the feature branch.
+- ⚪ **planned** — see [TODO / WIP](#todo--wip).
 
 ### Foundation
 
 | Branch | Status | PR |
 | :--- | :--- | :--- |
-| `modernize-base` — gradio drop, CORSMiddleware, audio_utils, shared workflows, unit test scaffolding (≥90% coverage) | ✅ merged | [#52](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/52) |
-| `docs/voice-pihole-hub` — this hub itself | 🟡 open | [#70](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/70) |
+| `modernize-base` | ✅ merged | [#52](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/52) |
+| `docs/voice-pihole-hub` | 🟡 open | [#70](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/70) |
 
 ### Commercial cloud STT
 
-| Vendor | Prefix(es) | Status | PR |
+| Vendor | Prefix | Status | PR |
 | :--- | :--- | :--- | :--- |
 | OpenAI Whisper | `/openai/v1/audio/*` | 🟡 open | [#53](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/53) |
 | Deepgram | `/deepgram/v1/listen` (HTTP + WS) | 🟡 open | [#54](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/54) |
 | Google Cloud STT | `/google/v1/speech:recognize` | 🟡 open | [#55](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/55) |
 | AssemblyAI | `/assemblyai/v2/{upload,transcript,realtime/ws}` | 🟡 open | [#56](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/56) |
-| Speechmatics | `/speechmatics/v1/{jobs*, ""}` (REST + WS) | 🟡 open | [#57](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/57) |
+| Speechmatics | `/speechmatics/v1` (REST + WS) | 🟡 open | [#57](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/57) |
 | Microsoft Azure Speech | `/azure-stt/cognitiveservices/v1` (REST + WS) | 🟡 open | [#58](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/58) |
 | AWS Transcribe | `/aws/transcribe` (batch + streaming WS) | 🟡 open | [#60](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/60) |
 | IBM Watson STT | `/watson/speech-to-text/v1/recognize` (REST + WS) | 🟡 open | [#61](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/61) |
@@ -56,97 +44,69 @@ its docs, examples, and live tests. **Status legend:**
 
 ### Self-hosted / open-source server protocols
 
-| Server | Prefix / surface | Status | PR |
+| Server | Surface | Status | PR |
 | :--- | :--- | :--- | :--- |
 | vosk-server (WebSocket) | `/vosk` | 🟡 open | [#63](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/63) |
-| vosk-server (gRPC) | `--vosk-grpc-port` opt-in | 🟡 open | [#65](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/65) |
-| vosk-server (WebRTC) | `/vosk-webrtc/offer` (opt-in extra) | 🟡 open | [#66](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/66) |
-| vosk-server (MQTT) | `--vosk-mqtt-broker` opt-in | 🟡 open | [#67](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/67) |
+| vosk-server (gRPC) | `--vosk-grpc-port` | 🟡 open | [#65](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/65) |
+| vosk-server (WebRTC) | `/vosk-webrtc/offer` | 🟡 open | [#66](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/66) |
+| vosk-server (MQTT) | `--vosk-mqtt-broker` | 🟡 open | [#67](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/67) |
 | kaldi-gstreamer-server | `/client/ws/speech` + `/client/dynamic/recognize` | 🟡 open | [#69](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/69) |
 | whisper.cpp HTTP server | `/whisper-cpp/inference` | 🟡 open | [#64](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/64) |
-| faster-whisper-server | re-uses `/openai/v1` | 🟡 open (docs only) | [#72](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/72) |
-| Wyoming (HA) | external adapter — see [wyoming-integration.md](wyoming-integration.md) | ✅ merged (adapter docs) | [#59](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/59) |
+| faster-whisper-server | re-uses `/openai/v1` | 🟡 open | [#72](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/72) |
+| Wyoming (HA) | external adapter — see [wyoming-integration.md](wyoming-integration.md) | ✅ merged | [#59](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/59) |
 
-### OpenAI-shape Whisper hosts (Tier 2 — no router code)
+### OpenAI-compatible Whisper hosts
 
-| Host | Status | PR |
+| Hosts | Status | PR |
 | :--- | :--- | :--- |
-| Groq, Cloudflare Workers AI, Fireworks AI, Together AI, OpenRouter | 🟡 open (docs only) | [#71](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/71) |
+| Groq, Cloudflare Workers AI, Fireworks AI, Together AI, OpenRouter | 🟡 open | [#71](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/71) |
 
 Apps targeting these hosts already speak the OpenAI `/v1/audio/transcriptions`
 contract — point them at our `/openai/v1` prefix.
 
-> :information_source: Status is updated on PR merge. Until a PR lands,
-> its per-vendor docs section lives on the feature branch — click the PR
-> link to read it. The status here reflects merge-into-`dev`, not local
-> implementation completeness.
+## Voice-pihole
 
-## Voice-pihole concept
-
-[voice-pihole.md](voice-pihole.md) collects every DNS-rewrite +
-nginx-reverse-proxy + CA-trust recipe across all the above vendors. Use
-it when you want unmodified consumer apps to transparently hit this
-server without any client-side configuration. The per-vendor sections in
-`api-compatibility.md` reference back into it.
+[voice-pihole.md](voice-pihole.md) collects every DNS-rewrite + reverse-proxy
++ CA-trust recipe across all the above vendors.
 
 ---
 
 ## TODO / WIP
 
-Things explicitly **not** done yet — open issues / PRs welcome.
-
 ### Streaming partial transcripts
 
-Every compat router that exposes a streaming surface (Deepgram WS,
-AssemblyAI realtime, Speechmatics RT, Azure WS, Watson WS, vosk WS,
-AWS streaming, Chromium) currently runs as **buffered batch**: audio is
-collected for the lifetime of the stream and a single final transcript is
-emitted on close / EOS. This is because OVOS STT plugins themselves are
-batch-only — they don't expose a partial / interim hypothesis interface.
+Every compat router with a streaming surface (Deepgram WS, AssemblyAI
+realtime, Speechmatics RT, Azure WS, Watson WS, vosk WS, AWS streaming,
+Chromium) runs as buffered batch — audio is collected for the lifetime
+of the stream and a single final transcript is emitted on close. OVOS
+STT plugins don't expose a partial / interim hypothesis interface.
 
-To produce true interim transcripts we'd need:
-
+Needed:
 - A VAD-driven chunker upstream of the OVOS plugin call, OR
-- New plugin-side support for streaming recognition (an OPM contract change)
-
-Tracking issue: TBD.
+- New plugin-side streaming support (OPM contract change).
 
 ### Vendor coverage gaps
 
-- **Web Speech API native protocol** — the binary `Sec-WebSocket-Protocol`
-  framing that modern Chrome/Edge use for the in-browser `SpeechRecognition`
-  Web API (distinct from the legacy `/speech-api/v2/recognize` REST that
-  PR #68 covers). Reverse-engineering needed.
-- **Rev.ai** — REST + streaming WS. Lower priority than the Tier-1 vendors
-  but apps in the media-transcription space use it.
-- **Soniox** — gRPC streaming. Niche but real.
-- **AssemblyAI streaming V3** — schema differs from the V2 realtime we
-  ship (PR #56). Add when V2 sunsets.
-- **Whisper.cpp's verbose-json with segments** — accepted today but
-  segment-level timestamps require a VAD pipeline OVOS plugins don't
-  expose. Tracked as part of "Streaming partial transcripts" above.
-- **AWS Transcribe streaming over real HTTP/2 event-stream** — we expose
-  a plain WS surface (PR #60) for ease of integration; the real upstream
-  uses AWS event-stream framing over HTTP/2. SDK-level apps that bypass
-  the WS path need a separate translator.
-- **Vosk gRPC `StatsService`** — `vosk-server`'s second proto service
-  (n_streams / n_total_streams / RTF) is not implemented (PR #65 ships
-  only `SttService.StreamingRecognize`).
+- **Web Speech API native binary protocol** — the `Sec-WebSocket-Protocol`
+  framing modern Chrome/Edge use for the in-browser `SpeechRecognition`
+  Web API. Distinct from the legacy `/speech-api/v2/recognize` REST (#68).
+- **Rev.ai** — REST + streaming WS.
+- **Soniox** — gRPC streaming.
+- **AssemblyAI streaming V3** — schema differs from the V2 realtime in #56.
+- **whisper.cpp `verbose_json` with segment timestamps** — needs VAD pipeline.
+- **AWS Transcribe streaming over real HTTP/2 event-stream** — #60 ships
+  a plain WS surface; SDK-level apps that bypass WS need a translator.
+- **vosk gRPC `StatsService`** — second proto service in #65's vendored
+  `.proto` not implemented.
 
 ### Documentation TODOs
 
-- One-pager per use-case ("running on a Raspberry Pi", "behind Tailscale",
-  "with Caddy instead of nginx") — voice-pihole.md is nginx-centric today.
-- A canonical mkcert / step-ca walkthrough for new self-hosters.
-- A migration guide from each vendor SDK to drop-in mode (per-vendor
-  config diff).
+- One-pager per use-case (Raspberry Pi, Tailscale, Caddy).
+- mkcert / step-ca walkthrough.
+- Per-vendor migration guide (SDK → drop-in mode).
 
 ### Process
 
-Once PR #70 (this hub) lands, every open compat PR rebases on `dev` and
-in its own diff:
-1. Removes its row's PR link from the master index in `api-compatibility.md`.
-2. Inlines its full docs section below the index.
-
-That converts each row from "in-flight" to "shipped + officialised". The
-TODO list above gets pruned as items land.
+Once #70 lands, every open compat PR rebases on `dev` and in its diff:
+1. Removes its row's PR link from the index in `api-compatibility.md`.
+2. Inlines its full per-vendor docs section.

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -1,15 +1,59 @@
-# API Compatibility Reference
+# API Compatibility
 
-`ovos-stt-http-server` exposes its underlying OVOS STT plugin behind drop-in
-compatibility endpoints for popular cloud STT APIs. Each vendor lives
-under its own URL prefix so multiple compat layers coexist with no path
-collisions.
+`ovos-stt-http-server` exposes its underlying OVOS STT plugin behind
+drop-in compatibility endpoints for popular cloud STT APIs. Each vendor
+lives under its own URL prefix so multiple compat layers coexist with no
+path collisions.
 
 All routers accept any auth token / API key from the client and silently
 ignore it — authentication is the responsibility of your reverse proxy.
 
-Audio format conversion is provided by `ovos_stt_http_server.audio_utils.multipart_audio_to_audiodata()`.
-Install the `[audio]` extra (`pip install ovos-stt-http-server[audio]`) to enable
+Audio format conversion is provided by
+`ovos_stt_http_server.audio_utils.multipart_audio_to_audiodata()`. Install
+the `[audio]` extra (`pip install ovos-stt-http-server[audio]`) to enable
 non-WAV inputs via `pydub`.
 
-Vendor sections are added by their respective compat-router PRs.
+The shared network-redirect concept lives in
+[`voice-pihole.md`](voice-pihole.md); per-vendor sections cross-reference it.
+
+Status reflects merge state into `dev`:
+
+- ✅ **merged** — full per-vendor docs section below the index.
+- 🟡 **open** — PR is up; full docs on the feature branch.
+
+## Commercial cloud STT
+
+| Vendor | Prefix | Status | PR |
+| :--- | :--- | :--- | :--- |
+| OpenAI Whisper | `/openai` | 🟡 open | [#53](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/53) |
+| Deepgram | `/deepgram` | 🟡 open | [#54](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/54) |
+| Google Cloud STT | `/google` | 🟡 open | [#55](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/55) |
+| AssemblyAI | `/assemblyai/v2` | 🟡 open | [#56](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/56) |
+| Speechmatics | `/speechmatics/v1` | 🟡 open | [#57](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/57) |
+| Microsoft Azure Speech | `/azure-stt` | 🟡 open | [#58](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/58) |
+| AWS Transcribe | `/aws` | 🟡 open | [#60](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/60) |
+| IBM Watson STT | `/watson/speech-to-text` | 🟡 open | [#61](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/61) |
+| Wit.ai | `/wit` | 🟡 open | [#62](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/62) |
+| Chromium Web Speech | `/speech-api/v2` | 🟡 open | [#68](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/68) |
+
+## Self-hosted / OSS server protocols
+
+| Server | Surface | Status | PR |
+| :--- | :--- | :--- | :--- |
+| vosk-server (WebSocket) | `/vosk` | 🟡 open | [#63](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/63) |
+| vosk-server (gRPC) | `--vosk-grpc-port` | 🟡 open | [#65](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/65) |
+| vosk-server (WebRTC) | `/vosk-webrtc/offer` | 🟡 open | [#66](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/66) |
+| vosk-server (MQTT) | `--vosk-mqtt-broker` | 🟡 open | [#67](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/67) |
+| kaldi-gstreamer-server | `/client/ws/speech` + `/client/dynamic/recognize` | 🟡 open | [#69](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/69) |
+| whisper.cpp HTTP server | `/whisper-cpp/inference` | 🟡 open | [#64](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/64) |
+| faster-whisper-server | re-uses `/openai/v1` | 🟡 open | [#72](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/72) |
+| Wyoming (HA) | external adapter | ✅ merged | see [`wyoming-integration.md`](wyoming-integration.md) |
+
+## OpenAI-compatible Whisper hosts
+
+| Hosts | Status | PR |
+| :--- | :--- | :--- |
+| Groq, Cloudflare Workers AI, Fireworks AI, Together AI, OpenRouter | 🟡 open | [#71](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/71) |
+
+Apps targeting these hosts already speak the OpenAI `/v1/audio/transcriptions`
+contract — point them at our `/openai/v1` prefix.

--- a/docs/audio-formats.md
+++ b/docs/audio-formats.md
@@ -15,5 +15,23 @@ shared helper `ovos_stt_http_server.audio_utils.multipart_audio_to_audiodata`:
 pip install ovos-stt-http-server[audio]
 ```
 
-If a non-WAV upload arrives and `pydub` is not installed, the server replies
-with `501 Not Implemented`.
+If a non-WAV upload arrives and `pydub` is not installed, the server
+replies with `501 Not Implemented`.
+
+## Vendor-specific notes
+
+| Vendor | Default content-type | Notes |
+| :--- | :--- | :--- |
+| OpenAI Whisper | `multipart/form-data` (`file=@`) | accepts whatever Whisper accepts |
+| Deepgram | `audio/wav` or raw PCM body | Content-Type sniffed |
+| Google Cloud STT | base64 in JSON body | `config.encoding` accepts `LINEAR16` or int 1 |
+| AssemblyAI | base64 in JSON or `audio_url` referencing `/v2/upload` | SDK-driven 3-step flow |
+| Speechmatics | `multipart/form-data` (`data_file=@`) | `config` form field carries JSON |
+| Azure Speech | `audio/wav` body (REST) or framed WS audio | rest accepts ≤60s |
+| AWS Transcribe | `data:audio/wav;base64,...` in `MediaFileUri` | inline only; S3 not fetched |
+| IBM Watson | `audio/wav` or `audio/l16;rate=16000` | WS uses `audio/l16` |
+| Wit.ai | `audio/wav` or `audio/raw;rate=...;bits=...` | content-type drives decoding |
+| Chromium | `audio/x-flac;rate=...` | FLAC encoder → pydub decoder |
+| vosk WS / MQTT | raw 16-bit PCM | rate from `config` |
+| kaldi-gstreamer | `audio/x-raw,rate=...,format=S16LE,...` caps | parsed from content-type |
+| whisper.cpp | `multipart/form-data` (`file=@`) | any audio pydub can read |

--- a/docs/voice-pihole.md
+++ b/docs/voice-pihole.md
@@ -1,0 +1,391 @@
+# Voice Pihole
+
+A single network-layer interception recipe per cloud STT vendor, so that
+**unmodified consumer apps stop calling cloud services** and land on your
+`ovos-stt-http-server` box instead. No client SDK changes, no API key
+swaps, no app-config edits — just DNS + a TLS-terminating reverse proxy.
+
+The pattern across every vendor is the same:
+
+1. **DNS interception.** Pin the vendor's hostname to your server's IP via
+   `/etc/hosts` (single host) or your LAN's DNS (Pi-hole / Unbound /
+   dnsmasq / pfSense / OPNsense).
+2. **TLS termination.** Run nginx (or Caddy / HAProxy / Envoy) on `443`
+   for the vendor's hostname, holding a cert your clients trust.
+3. **Path rewrite.** Map the vendor's upstream path to our internal prefix
+   so the rest of FastAPI's routing works.
+4. **CA trust.** Either sign the proxy cert with a CA the client already
+   trusts (corporate PKI, mkcert root) or push the CA into the client's
+   trust store (`REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, system trust).
+
+This document holds the consolidated config. Each per-vendor section in
+[`api-compatibility.md`](api-compatibility.md) references the matching
+block here.
+
+> :warning: **Intercepting a hostname catches *every* request to it.**
+> `www.google.com` is shared with chat, search, Drive, etc.; intercepting
+> it without forwarding the non-STT paths back upstream will break those
+> features on the client. The example configs below isolate the STT path
+> and either 404 or transparent-proxy everything else.
+
+---
+
+## Common nginx prelude
+
+Every server block below assumes this `map` directive is in your
+`nginx.conf` (or in a `conf.d/*.conf` snippet loaded into `http {}`):
+
+```nginx
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+```
+
+It's needed any time a WS upgrade is forwarded.
+
+---
+
+## Cert + CA trust setup
+
+For each hostname you intercept you need an X.509 cert with the vendor's
+hostname in the SAN list. Two common approaches:
+
+### A) Internal CA (production)
+
+1. Generate an internal CA (e.g. via `step-ca`, `cfssl`, or even
+   `openssl`).
+2. Install the CA cert in the client device's trust store (corporate
+   MDM, dotfiles, system keychain, `update-ca-certificates`).
+3. Issue per-hostname leaf certs from this CA.
+
+This is what corporate VPN + DLP deployments already do — re-use that
+trust chain.
+
+### B) mkcert (lab / dev)
+
+```bash
+brew install mkcert  # or apt / scoop / cargo
+mkcert -install
+mkcert api.openai.com api.deepgram.com '*.googleapis.com' \
+       api.assemblyai.com api.wit.ai \
+       '*.speech.microsoft.com' \
+       'transcribe.*.amazonaws.com' \
+       'api.*.speech-to-text.watson.cloud.ibm.com' \
+       'asr.api.speechmatics.com'
+```
+
+mkcert installs its CA into the system trust automatically.
+
+---
+
+## Per-vendor nginx blocks
+
+### OpenAI Whisper (`api.openai.com`)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name api.openai.com;
+    ssl_certificate     /etc/ssl/private/api.openai.com.crt;
+    ssl_certificate_key /etc/ssl/private/api.openai.com.key;
+
+    # Audio endpoints → /openai/v1/audio/*
+    location /v1/audio/ {
+        proxy_pass         http://127.0.0.1:8080/openai/v1/audio/;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+    # Some SDKs probe /v1/models at startup; return a benign stub
+    location /v1/models {
+        return 200 '{"data":[]}';
+        add_header Content-Type application/json;
+    }
+    location / { return 404; }
+}
+```
+
+### Deepgram (`api.deepgram.com`, REST + WS)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name api.deepgram.com;
+    ssl_certificate     /etc/ssl/private/api.deepgram.com.crt;
+    ssl_certificate_key /etc/ssl/private/api.deepgram.com.key;
+
+    location /v1/listen {
+        proxy_pass         http://127.0.0.1:8080/deepgram/v1/listen;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+        proxy_read_timeout 300s;
+    }
+    location / { return 404; }
+}
+```
+
+### Google Cloud STT (`speech.googleapis.com`)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name speech.googleapis.com;
+    ssl_certificate     /etc/ssl/private/speech.googleapis.com.crt;
+    ssl_certificate_key /etc/ssl/private/speech.googleapis.com.key;
+
+    location /v1/speech:recognize {
+        proxy_pass         http://127.0.0.1:8080/google/v1/speech:recognize;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+    location / { return 404; }
+}
+```
+
+> :information_source: The `google-cloud-speech` Python SDK builds host-only
+> endpoints; for it to work you also need the in-Python monkey-patch
+> documented in `api-compatibility.md` under Google STT. Raw REST clients
+> don't need that.
+
+### AssemblyAI (`api.assemblyai.com`, REST + realtime WS)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name api.assemblyai.com;
+    ssl_certificate     /etc/ssl/private/api.assemblyai.com.crt;
+    ssl_certificate_key /etc/ssl/private/api.assemblyai.com.key;
+
+    location /v2/ {
+        proxy_pass         http://127.0.0.1:8080/assemblyai/v2/;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_set_header   Host $host;
+        proxy_request_buffering off;
+        proxy_buffering          off;
+        proxy_read_timeout       300s;
+    }
+    location / { return 404; }
+}
+```
+
+### Speechmatics (batch `asr.api.speechmatics.com` + realtime `eu2.rt.speechmatics.com`)
+
+```nginx
+# Batch host
+server {
+    listen 443 ssl;
+    server_name asr.api.speechmatics.com;
+    ssl_certificate     /etc/ssl/private/asr.api.speechmatics.com.crt;
+    ssl_certificate_key /etc/ssl/private/asr.api.speechmatics.com.key;
+
+    location /v2/ {
+        rewrite ^/v2/(.*)$ /speechmatics/v1/$1 break;
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+    location / { return 404; }
+}
+
+# Realtime host
+server {
+    listen 443 ssl;
+    server_name eu2.rt.speechmatics.com;
+    ssl_certificate     /etc/ssl/private/eu2.rt.speechmatics.com.crt;
+    ssl_certificate_key /etc/ssl/private/eu2.rt.speechmatics.com.key;
+
+    location = /v2 {
+        proxy_pass         http://127.0.0.1:8080/speechmatics/v1;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_set_header   Host $host;
+        proxy_read_timeout 300s;
+    }
+    location / { return 404; }
+}
+```
+
+### Microsoft Azure Speech (`*.stt.speech.microsoft.com`)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name ~^[a-z0-9]+\.stt\.speech\.microsoft\.com$;
+    ssl_certificate     /etc/ssl/private/stt.speech.microsoft.com.crt;
+    ssl_certificate_key /etc/ssl/private/stt.speech.microsoft.com.key;
+
+    location /speech/recognition/conversation/cognitiveservices/v1 {
+        proxy_pass         http://127.0.0.1:8080/azure-stt/cognitiveservices/v1;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+        proxy_read_timeout 300s;
+    }
+    location / { return 404; }
+}
+```
+
+### AWS Transcribe (`transcribe.*.amazonaws.com` + `transcribestreaming.*.amazonaws.com`)
+
+```nginx
+# Batch
+server {
+    listen 443 ssl;
+    server_name ~^transcribe\.[a-z0-9-]+\.amazonaws\.com$;
+    ssl_certificate     /etc/ssl/private/transcribe.amazonaws.com.crt;
+    ssl_certificate_key /etc/ssl/private/transcribe.amazonaws.com.key;
+
+    location = / {
+        proxy_pass         http://127.0.0.1:8080/aws/transcribe;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+    location / { return 404; }
+}
+
+# Streaming
+server {
+    listen 443 ssl;
+    server_name ~^transcribestreaming\.[a-z0-9-]+\.amazonaws\.com$;
+    ssl_certificate     /etc/ssl/private/transcribestreaming.amazonaws.com.crt;
+    ssl_certificate_key /etc/ssl/private/transcribestreaming.amazonaws.com.key;
+
+    location /stream-transcription {
+        proxy_pass         http://127.0.0.1:8080/aws/transcribestreaming/stream-transcription;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_set_header   Host $host;
+        proxy_read_timeout 300s;
+        proxy_buffering    off;
+    }
+    location / { return 404; }
+}
+```
+
+### IBM Watson STT (`api.*.speech-to-text.watson.cloud.ibm.com`)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name ~^api\.[a-z0-9-]+\.speech-to-text\.watson\.cloud\.ibm\.com$;
+    ssl_certificate     /etc/ssl/private/watson-stt.crt;
+    ssl_certificate_key /etc/ssl/private/watson-stt.key;
+
+    location /v1/recognize {
+        proxy_pass         http://127.0.0.1:8080/watson/speech-to-text/v1/recognize;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+        proxy_read_timeout 300s;
+    }
+    location / { return 404; }
+}
+```
+
+### Wit.ai (`api.wit.ai`)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name api.wit.ai;
+    ssl_certificate     /etc/ssl/private/api.wit.ai.crt;
+    ssl_certificate_key /etc/ssl/private/api.wit.ai.key;
+
+    location /speech {
+        proxy_pass         http://127.0.0.1:8080/wit/speech;
+        proxy_set_header   Host $host;
+        proxy_request_buffering off;
+        proxy_buffering          off;
+    }
+    location / { return 404; }
+}
+```
+
+### Chromium / Chrome Web Speech (`www.google.com/speech-api`)
+
+This one is special — `www.google.com` is shared with **every other Google
+service**, so the nginx block must forward unrelated paths back to the
+real Google. The upstream endpoint is plain HTTP, but modern Chrome may
+upgrade it to HTTPS — listen on both.
+
+```nginx
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name www.google.com;
+    ssl_certificate     /etc/ssl/private/www.google.com.crt;
+    ssl_certificate_key /etc/ssl/private/www.google.com.key;
+
+    # STT path → us
+    location /speech-api/ {
+        proxy_pass         http://127.0.0.1:8080/speech-api/;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+
+    # Everything else proxied to the real Google so other features keep
+    # working. Resolver bypasses our hosts/DNS rewrite so we hit real DNS.
+    resolver 8.8.8.8 1.1.1.1 ipv6=off valid=300s;
+    location / {
+        set $upstream "www.google.com";
+        proxy_pass         https://$upstream$request_uri;
+        proxy_set_header   Host www.google.com;
+        proxy_ssl_server_name on;
+    }
+}
+```
+
+---
+
+## Self-hosted server replacement
+
+For self-hosted protocols (vosk-server, kaldi-gstreamer-server,
+whisper.cpp) you usually replace them at the bind-port level rather than
+intercepting a public hostname. Stop the old process; start
+ovos-stt-http-server on the same port; clients keep working.
+
+See each per-protocol section in `api-compatibility.md` for the matching
+nginx config (most just need the port-swap and a single `location /`
+rewrite to our internal prefix).
+
+---
+
+## Putting it together
+
+A complete "voice pihole" deployment is:
+
+```
+┌──────────────────────────────┐
+│   Pi-hole / Unbound / pfSense│   1) DNS rewrites for all the hosts above
+│   (LAN-wide DNS)             │
+└──────────────┬───────────────┘
+               │ resolves api.openai.com etc. → 192.168.1.50
+               ▼
+┌──────────────────────────────┐
+│   nginx (192.168.1.50:443)   │   2) TLS termination + path rewrite
+│   - one server{} per vendor  │   3) cert from a CA trusted on clients
+└──────────────┬───────────────┘
+               │ proxies to 127.0.0.1:8080/<vendor-prefix>/...
+               ▼
+┌──────────────────────────────┐
+│   ovos-stt-http-server       │   4) compat router for each vendor
+│   :8080 (HTTP)               │      → OVOS STT plugin (the actual ASR)
+│   :50051 (vosk-gRPC, opt-in) │
+│   MQTT bridge (opt-in)       │
+└──────────────────────────────┘
+```
+
+Once the DNS rewrite + TLS cert + reverse proxy are in place, **every**
+consumer app on the LAN that uses any of the above APIs is automatically
+served by your local OVOS plugin — no client-side change required.


### PR DESCRIPTION
## Summary

Docs-only PR that introduces the documentation hub for all compat routers and consolidates the network-redirect ("voice pihole") nginx configuration into a single source of truth.

### Files added

- \`docs/README.md\` — top-level index. Coverage matrix listing every compat surface with its URL prefix and shipping status.
- \`docs/voice-pihole.md\` — **the** voice-pihole guide. One nginx \`server{}\` block per vendor host (\`api.openai.com\`, \`api.deepgram.com\`, \`speech.googleapis.com\`, etc.), plus a Common Prelude, a CA-trust section (mkcert / internal CA), and a topology diagram. Per-vendor docs in \`api-compatibility.md\` will cross-reference this file instead of duplicating nginx blocks.
- \`docs/api-compatibility.md\` — master index of compat PRs. Each row points to its in-flight PR URL; on PR merge each compat branch will replace its own row with the inline per-vendor docs section.
- \`docs/audio-formats.md\` — audio-format expectations table per vendor.
- \`docs/wyoming-integration.md\` — explains the Wyoming adapter-repo route (consolidated here for the hub).

### Merge order

1. **This PR is merged first.** No code changes; only adds new docs files.
2. Each open compat PR (#52–#69) rebases on top of \`dev\` (which now has \`/docs\`), and in that rebase replaces its row in \`docs/api-compatibility.md\`'s master index with the full per-vendor section — the PR URL goes away when the PR merges, and the official docs live in this hub from then on.

This gives readers one front door (\`docs/README.md\`) and one canonical nginx reference (\`docs/voice-pihole.md\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)