### PR TITLE
ci: scope coverage to source package only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,11 @@ include = ["ovos_stt_http_server*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "ovos_stt_http_server.version.__version__"}
+
+[tool.coverage.run]
+source = ["ovos_stt_http_server"]
+omit = [
+    "test/*",
+    "*/proto/*_pb2.py",
+    "*/proto/*_pb2_grpc.py",
+]


### PR DESCRIPTION
Coverage on every compat PR (#54–#72) reports ~79% because pytest-cov measures `test/integration/*` file bodies (47+ lines per branch) that are imported during collection. The package itself is at 95%+ everywhere.

Scopes coverage to `ovos_stt_http_server` and omits the auto-generated proto stubs (`*_pb2.py` / `*_pb2_grpc.py` from #65). After merge, every open compat PR's coverage step passes on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)