### PR TITLE
feat(compat): add Groq, Gladia and ElevenLabs Scribe STT-compatible endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ options:
 
 eg `ovos-stt-server --engine ovos-stt-plugin-fasterwhisper --lang-engine ovos-audio-transformer-plugin-fasterwhisper`
 
+## Vendor-compatible endpoints
+
+Besides the native `/stt` endpoint, the server mounts drop-in compatibility
+routers so existing clients of popular STT APIs can be repointed at a
+self-hosted OVOS plugin. Each is mounted under its own prefix:
+
+| Vendor | Prefix | Endpoint | Auth field (accepted, ignored) |
+|---|---|---|---|
+| OpenAI Whisper | `/v1` | `POST /v1/audio/transcriptions` | `Authorization: Bearer` |
+| Groq | `/groq` | `POST /groq/openai/v1/audio/transcriptions` | `Authorization: Bearer` |
+| ElevenLabs Scribe | `/elevenlabs` | `POST /elevenlabs/v1/speech-to-text` | `xi-api-key` |
+| Gladia | `/gladia` | `POST /v2/upload` → `POST /v2/transcription` → `GET /v2/transcription/{id}` | `x-gladia-key` |
+| Deepgram | `/deepgram` | `POST /deepgram/v1/listen` (+ WS) | `Authorization: Token` |
+| AssemblyAI, Speechmatics, Google, Azure, AWS Transcribe, IBM Watson, Wit.ai, Chromium, Kaldi, Vosk, whisper.cpp | see `ovos_stt_http_server/routers/` | — | — |
+
+Point any client SDK at the matching prefix; the `model`/API-key fields are
+accepted for compatibility but the configured OVOS plugin is always used.
+Runnable examples for each vendor SDK live in [`examples/`](examples/) (e.g.
+`groq_example.py`, `elevenlabs_scribe_example.py`, `gladia_example.py`).
+
+Groq is OpenAI-compatible, so the `/groq` prefix differs from `/v1` only by the
+path Groq clients expect (`/openai/v1/...`) and the extra `x_groq` block in the
+response.
+
 ## Docker
 
 you can create easily create a docker file to serve any plugin

--- a/examples/elevenlabs_scribe_example.py
+++ b/examples/elevenlabs_scribe_example.py
@@ -1,0 +1,28 @@
+"""Drive the official ElevenLabs SDK (Scribe STT) against ovos-stt-http-server.
+
+Prerequisites:
+    pip install elevenlabs
+    ovos-stt-server --engine <some-ovos-stt-plugin> --port 8080
+
+Usage:
+    python examples/elevenlabs_scribe_example.py path/to/clip.wav
+"""
+import sys
+
+from elevenlabs.client import ElevenLabs
+
+
+OVOS_HOST = "http://localhost:8080"
+
+
+def main(audio_path: str) -> None:
+    client = ElevenLabs(api_key="ignored", base_url=f"{OVOS_HOST}/elevenlabs")
+    with open(audio_path, "rb") as f:
+        result = client.speech_to_text.convert(file=f, model_id="scribe_v1")
+    print(result.text)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <audio.wav>")
+    main(sys.argv[1])

--- a/examples/gladia_example.py
+++ b/examples/gladia_example.py
@@ -1,0 +1,42 @@
+"""Drive Gladia's v2 upload -> transcription -> poll flow against ovos-stt-http-server.
+
+Gladia's API is asynchronous; ovos-stt-http-server runs the OVOS engine
+synchronously, so the job is already ``done`` on the first poll.
+
+Prerequisites:
+    pip install requests
+    ovos-stt-server --engine <some-ovos-stt-plugin> --port 8080
+
+Usage:
+    python examples/gladia_example.py path/to/clip.wav
+"""
+import sys
+
+import requests
+
+
+OVOS_HOST = "http://localhost:8080/gladia"
+
+
+def main(audio_path: str) -> None:
+    with open(audio_path, "rb") as f:
+        up = requests.post(f"{OVOS_HOST}/v2/upload",
+                           files={"audio": (audio_path, f, "audio/wav")})
+    up.raise_for_status()
+    audio_url = up.json()["audio_url"]
+    if audio_url.startswith("/"):
+        audio_url = f"http://localhost:8080{audio_url}"
+
+    tx = requests.post(f"{OVOS_HOST}/v2/transcription", json={"audio_url": audio_url})
+    tx.raise_for_status()
+    job_id = tx.json()["id"]
+
+    res = requests.get(f"{OVOS_HOST}/v2/transcription/{job_id}")
+    res.raise_for_status()
+    print(res.json()["result"]["transcription"]["full_transcript"])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <audio.wav>")
+    main(sys.argv[1])

--- a/examples/gladia_example.py
+++ b/examples/gladia_example.py
@@ -3,6 +3,9 @@
 Gladia's API is asynchronous; ovos-stt-http-server runs the OVOS engine
 synchronously, so the job is already ``done`` on the first poll.
 
+Gladia has **no official Python SDK** (it is consumed over its REST API), so
+this example calls the HTTP endpoints directly rather than driving a vendor SDK.
+
 Prerequisites:
     pip install requests
     ovos-stt-server --engine <some-ovos-stt-plugin> --port 8080

--- a/examples/groq_example.py
+++ b/examples/groq_example.py
@@ -1,0 +1,36 @@
+"""Drive the official Groq SDK against an ovos-stt-http-server instance.
+
+Groq exposes Whisper through an OpenAI-compatible surface rooted at
+``/openai/v1``; the ovos-stt-http-server Groq router mounts the same shape
+under ``/groq``.
+
+Prerequisites:
+    pip install groq
+    ovos-stt-server --engine <some-ovos-stt-plugin> --port 8080
+
+Usage:
+    python examples/groq_example.py path/to/clip.wav
+"""
+import sys
+from pathlib import Path
+
+from groq import Groq
+
+
+OVOS_HOST = "http://localhost:8080"
+
+
+def main(audio_path: str) -> None:
+    client = Groq(api_key="ignored", base_url=f"{OVOS_HOST}/groq")
+    with open(audio_path, "rb") as f:
+        result = client.audio.transcriptions.create(
+            file=(Path(audio_path).name, f.read()),
+            model="whisper-large-v3",
+        )
+    print(result.text)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <audio.wav>")
+    main(sys.argv[1])

--- a/ovos_stt_http_server/__init__.py
+++ b/ovos_stt_http_server/__init__.py
@@ -220,6 +220,12 @@ def create_app(stt_plugin: str, lang_plugin: str = None, multi: bool = False):
     from ovos_stt_http_server.routers.aws_transcribe import make_aws_transcribe_router
     app.include_router(make_aws_transcribe_router(model))
     app.include_router(make_deepgram_router(model))
+    from ovos_stt_http_server.routers.groq import make_groq_router
+    app.include_router(make_groq_router(model))
+    from ovos_stt_http_server.routers.gladia import make_gladia_router
+    app.include_router(make_gladia_router(model))
+    from ovos_stt_http_server.routers.elevenlabs_scribe import make_elevenlabs_scribe_router
+    app.include_router(make_elevenlabs_scribe_router(model))
 
     # Mount MCP server when the optional dependency is available.
     try:

--- a/ovos_stt_http_server/routers/elevenlabs_scribe.py
+++ b/ovos_stt_http_server/routers/elevenlabs_scribe.py
@@ -1,0 +1,102 @@
+# Licensed under the Apache License, Version 2.0
+"""ElevenLabs Scribe-compatible STT endpoint.
+
+ElevenLabs' speech-to-text product (Scribe) exposes a single
+``POST /v1/speech-to-text`` endpoint that accepts ``multipart/form-data`` with
+a ``file`` part and a ``model_id`` field, authenticated with an ``xi-api-key``
+header.  The JSON response carries ``language_code``, ``language_probability``,
+``text`` and a ``words`` array.
+
+Usage::
+
+    from ovos_stt_http_server.routers.elevenlabs_scribe import make_elevenlabs_scribe_router
+    app.include_router(make_elevenlabs_scribe_router(model))
+
+Then point the SDK at the server::
+
+    from elevenlabs.client import ElevenLabs
+    client = ElevenLabs(api_key="ignored", base_url="http://localhost:8080")
+    result = client.speech_to_text.convert(file=audio, model_id="scribe_v1")
+"""
+import io
+import wave
+from typing import List, Optional
+
+from fastapi import APIRouter, File, Form, HTTPException, Header, UploadFile
+from pydantic import BaseModel, Field
+
+from ovos_plugin_manager.utils.audio import AudioData
+
+
+class ScribeWord(BaseModel):
+    """A single token in a Scribe transcript."""
+    text: str
+    type: str = "word"
+    start: float = 0.0
+    end: float = 0.0
+
+
+class ScribeResponse(BaseModel):
+    """ElevenLabs Scribe speech-to-text response."""
+    language_code: str = Field(..., description="Detected/declared language.")
+    language_probability: float = Field(default=1.0, ge=0.0, le=1.0)
+    text: str = Field(..., description="Full transcript.")
+    words: List[ScribeWord] = Field(default_factory=list)
+
+
+def _audio_data_from_upload(file_bytes: bytes, sample_rate: int = 16000, sample_width: int = 2) -> AudioData:
+    """Wrap uploaded bytes in AudioData, reading WAV metadata when present."""
+    try:
+        with wave.open(io.BytesIO(file_bytes), "r") as wf:
+            sample_rate = wf.getframerate()
+            sample_width = wf.getsampwidth()
+            file_bytes = wf.readframes(wf.getnframes())
+    except Exception:
+        pass  # not a WAV — use raw bytes with defaults
+    return AudioData(file_bytes, sample_rate, sample_width)
+
+
+def make_elevenlabs_scribe_router(model) -> APIRouter:
+    """Create an ElevenLabs Scribe-compatible router and attach it to *model*.
+
+    Exposes ``POST /elevenlabs/v1/speech-to-text``. The ``model_id`` and
+    ``xi-api-key`` fields are accepted for client compatibility but not
+    forwarded to the OVOS engine.
+
+    Args:
+        model: Any object with ``process_audio(audio: AudioData, lang: str)``
+            returning a transcription string.
+
+    Returns:
+        Configured :class:`~fastapi.APIRouter` prefixed with ``/elevenlabs``.
+    """
+    router = APIRouter(prefix="/elevenlabs", tags=["elevenlabs-scribe"])
+
+    @router.post(
+        "/v1/speech-to-text",
+        response_model=ScribeResponse,
+        summary="Transcribe audio (ElevenLabs Scribe-compatible)",
+    )
+    async def speech_to_text(
+        file: UploadFile = File(..., description="Audio file to transcribe."),
+        model_id: str = Form(default="scribe_v1", description="Model id (accepted, ignored)."),
+        language_code: Optional[str] = Form(default=None, description="ISO-639 language code."),
+        xi_api_key: Optional[str] = Header(default=None, alias="xi-api-key", description="API key (accepted, ignored)."),
+    ) -> ScribeResponse:
+        """Transcribe audio using the OVOS STT plugin, Scribe response shape."""
+        file_bytes = await file.read()
+        if not file_bytes:
+            raise HTTPException(status_code=400, detail="Empty audio file.")
+
+        audio = _audio_data_from_upload(file_bytes)
+        lang = language_code or "auto"
+        transcript = model.process_audio(audio, lang) or ""
+
+        return ScribeResponse(
+            language_code=lang if lang != "auto" else "en",
+            language_probability=1.0,
+            text=transcript,
+            words=[],
+        )
+
+    return router

--- a/ovos_stt_http_server/routers/gladia.py
+++ b/ovos_stt_http_server/routers/gladia.py
@@ -1,0 +1,135 @@
+# Licensed under the Apache License, Version 2.0
+"""Gladia-compatible STT endpoints.
+
+Gladia's v2 API is a three-step asynchronous flow:
+
+1. ``POST /v2/upload`` — multipart audio upload, returns an ``audio_url``.
+2. ``POST /v2/transcription`` — JSON ``{"audio_url": ...}``, returns an ``id``
+   and a ``result_url``.
+3. ``GET /v2/transcription/{id}`` — poll until ``status == "done"``; the result
+   carries ``result.transcription.full_transcript``.
+
+OVOS STT plugins are batch engines, so this router keeps an in-memory job store
+and runs transcription synchronously at step 2: the job is already ``done`` by
+the time the client polls, but the full async wire format is preserved so that
+existing Gladia clients work unchanged.
+
+Usage::
+
+    from ovos_stt_http_server.routers.gladia import make_gladia_router
+    app.include_router(make_gladia_router(model))
+"""
+import time
+import uuid
+from typing import Dict, Optional
+
+from fastapi import APIRouter, File, HTTPException, Header, UploadFile
+from pydantic import BaseModel, Field
+
+from ovos_plugin_manager.utils.audio import AudioData
+
+
+class GladiaUploadResponse(BaseModel):
+    """Response for POST /v2/upload."""
+    audio_url: str
+    audio_metadata: dict = Field(default_factory=dict)
+
+
+class GladiaTranscriptionRequest(BaseModel):
+    """Request body for POST /v2/transcription."""
+    audio_url: str
+    language: Optional[str] = None
+    detect_language: bool = True
+
+
+class GladiaTranscriptionInit(BaseModel):
+    """Response for POST /v2/transcription (job accepted)."""
+    id: str
+    result_url: str
+
+
+def make_gladia_router(model, base_url: str = "") -> APIRouter:
+    """Create a Gladia-compatible router and attach it to *model*.
+
+    Implements the three-step upload → transcription → poll flow with a
+    synchronous in-memory job store. Audio uploaded at ``/v2/upload`` is held
+    in memory keyed by a generated ``audio_url`` and transcribed when the
+    matching ``/v2/transcription`` request arrives; the result is then served
+    by ``GET /v2/transcription/{id}``.
+
+    Args:
+        model: Any object with ``process_audio(audio: AudioData, lang: str)``
+            returning a transcription string.
+        base_url: Optional absolute base (e.g. ``http://host:8080``) used to
+            build ``audio_url``/``result_url`` values. Defaults to relative
+            paths, which is sufficient for SDK clients that resolve against
+            their configured base.
+
+    Returns:
+        Configured :class:`~fastapi.APIRouter` prefixed with ``/gladia``.
+    """
+    router = APIRouter(prefix="/gladia", tags=["gladia"])
+
+    # audio_url -> {data, sr, sw};  job id -> result dict
+    _uploads: Dict[str, AudioData] = {}
+    _jobs: Dict[str, dict] = {}
+
+    def _url(path: str) -> str:
+        return f"{base_url}{path}" if base_url else path
+
+    @router.post("/v2/upload", response_model=GladiaUploadResponse)
+    async def upload(
+        audio: UploadFile = File(...),
+        x_gladia_key: Optional[str] = Header(default=None, alias="x-gladia-key"),
+    ) -> GladiaUploadResponse:
+        """Accept an audio upload and return a handle ``audio_url``."""
+        data = await audio.read()
+        if not data:
+            raise HTTPException(status_code=400, detail="Empty audio file.")
+        key = uuid.uuid4().hex
+        # default 16kHz 16-bit mono; OVOS plugins normalise internally
+        _uploads[key] = AudioData(data, 16000, 2)
+        return GladiaUploadResponse(
+            audio_url=_url(f"/gladia/v2/upload/{key}"),
+            audio_metadata={"filename": audio.filename or "audio"},
+        )
+
+    @router.post("/v2/transcription", response_model=GladiaTranscriptionInit, status_code=201)
+    async def transcription(
+        req: GladiaTranscriptionRequest,
+        x_gladia_key: Optional[str] = Header(default=None, alias="x-gladia-key"),
+    ) -> GladiaTranscriptionInit:
+        """Run transcription synchronously and register a finished job."""
+        key = req.audio_url.rstrip("/").split("/")[-1]
+        audio = _uploads.get(key)
+        if audio is None:
+            raise HTTPException(status_code=404, detail="Unknown audio_url.")
+        lang = req.language or "auto"
+        transcript = model.process_audio(audio, lang) or ""
+        job_id = uuid.uuid4().hex
+        _jobs[job_id] = {
+            "id": job_id,
+            "status": "done",
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime()),
+            "result": {
+                "transcription": {
+                    "full_transcript": transcript,
+                    "languages": [lang if lang != "auto" else "en"],
+                    "utterances": [],
+                },
+            },
+        }
+        return GladiaTranscriptionInit(id=job_id, result_url=_url(f"/gladia/v2/transcription/{job_id}"))
+
+    @router.get("/v2/transcription/{job_id}")
+    async def get_transcription(
+        job_id: str,
+        x_gladia_key: Optional[str] = Header(default=None, alias="x-gladia-key"),
+    ) -> dict:
+        """Return the finished job result (Gladia poll endpoint)."""
+        job = _jobs.get(job_id)
+        if job is None:
+            raise HTTPException(status_code=404, detail="Unknown transcription id.")
+        return job
+
+    return router

--- a/ovos_stt_http_server/routers/groq.py
+++ b/ovos_stt_http_server/routers/groq.py
@@ -1,0 +1,104 @@
+# Licensed under the Apache License, Version 2.0
+"""Groq-compatible STT endpoint.
+
+Groq serves Whisper through an OpenAI-compatible surface rooted at
+``/openai/v1``.  Existing Groq clients (the official ``groq`` SDK, or the
+``openai`` SDK pointed at ``https://api.groq.com/openai/v1``) send
+``multipart/form-data`` to ``POST /openai/v1/audio/transcriptions`` exactly as
+the OpenAI Whisper API does; the JSON response carries an extra ``x_groq``
+metadata block.
+
+Usage::
+
+    from ovos_stt_http_server.routers.groq import make_groq_router
+    app.include_router(make_groq_router(model))
+
+Then point the SDK at the server::
+
+    from groq import Groq
+    client = Groq(api_key="ignored", base_url="http://localhost:8080")
+    result = client.audio.transcriptions.create(file=audio, model="whisper-large-v3")
+"""
+import io
+import time
+import uuid
+import wave
+from typing import Optional
+
+from fastapi import APIRouter, File, Form, HTTPException, Header, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+from ovos_plugin_manager.utils.audio import AudioData
+
+
+def _audio_data_from_upload(file_bytes: bytes, sample_rate: int = 16000, sample_width: int = 2) -> AudioData:
+    """Wrap uploaded bytes in AudioData, reading WAV metadata when present."""
+    try:
+        with wave.open(io.BytesIO(file_bytes), "r") as wf:
+            sample_rate = wf.getframerate()
+            sample_width = wf.getsampwidth()
+            file_bytes = wf.readframes(wf.getnframes())
+    except Exception:
+        pass  # not a WAV — use raw bytes with defaults
+    return AudioData(file_bytes, sample_rate, sample_width)
+
+
+def make_groq_router(model) -> APIRouter:
+    """Create a Groq-compatible router and attach it to *model*.
+
+    Exposes ``POST /groq/openai/v1/audio/transcriptions`` accepting the same
+    ``multipart/form-data`` payload as the OpenAI Whisper API. The ``model`` and
+    auth fields are accepted for client compatibility but not forwarded to the
+    OVOS engine.
+
+    Args:
+        model: Any object with ``process_audio(audio: AudioData, lang: str)``
+            returning a transcription string.
+
+    Returns:
+        Configured :class:`~fastapi.APIRouter` prefixed with ``/groq``.
+    """
+    router = APIRouter(prefix="/groq", tags=["groq"])
+
+    @router.post(
+        "/openai/v1/audio/transcriptions",
+        summary="Transcribe audio (Groq Whisper-compatible)",
+    )
+    async def transcriptions(
+        file: UploadFile = File(..., description="Audio file to transcribe."),
+        model_name: str = Form(..., alias="model", description="Model name (accepted, ignored)."),
+        language: Optional[str] = Form(default=None, description="ISO-639-1 language code."),
+        prompt: Optional[str] = Form(default=None, description="Prompt hint (accepted, ignored)."),
+        response_format: Optional[str] = Form(default="json", description="json, text or verbose_json."),
+        temperature: Optional[float] = Form(default=0.0, description="Sampling temperature (ignored)."),
+        authorization: Optional[str] = Header(default=None, description="Bearer token (accepted, ignored)."),
+    ):
+        """Transcribe audio using the OVOS STT plugin, Groq response shape.
+
+        Returns ``{"text": ..., "x_groq": {...}}`` for ``json``/``verbose_json``
+        (the extra ``x_groq`` block is what distinguishes Groq from plain
+        OpenAI), or plain text for ``text``.
+        """
+        file_bytes = await file.read()
+        if not file_bytes:
+            raise HTTPException(status_code=400, detail="Empty audio file.")
+
+        audio = _audio_data_from_upload(file_bytes)
+        lang = language or "auto"
+        transcript = model.process_audio(audio, lang) or ""
+
+        fmt = (response_format or "json").lower()
+        if fmt == "text":
+            return PlainTextResponse(content=transcript)
+        if fmt in ("json", "verbose_json"):
+            return JSONResponse(content={
+                "text": transcript,
+                "x_groq": {"id": f"req_{uuid.uuid4().hex[:24]}"},
+            })
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported response_format: {response_format!r}. "
+                   f"Use one of: json, text, verbose_json.",
+        )
+
+    return router

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 audio = ["pydub"]
-test = ["pytest", "httpx", "pytest-cov", "python-multipart", "requests", "uvicorn", "websockets", "deepgram-sdk", "grpcio", "protobuf", "grpcio-tools", "paho-mqtt", "amqtt"]
+test = ["pytest", "httpx", "pytest-cov", "python-multipart", "requests", "uvicorn", "websockets", "deepgram-sdk", "groq", "elevenlabs", "grpcio", "protobuf", "grpcio-tools", "paho-mqtt", "amqtt"]
 mcp = ["mcp>=1.0.0"]
 
 [project.urls]

--- a/test/integration/test_elevenlabs_scribe_sdk_live.py
+++ b/test/integration/test_elevenlabs_scribe_sdk_live.py
@@ -1,0 +1,33 @@
+"""Live test: drive the official ElevenLabs SDK (Scribe STT) against our
+/elevenlabs router.
+
+The client defaults to ``https://api.elevenlabs.io`` and appends
+``/v1/speech-to-text``; pointing ``base_url`` at ``{server}/elevenlabs`` makes
+it hit our router unchanged.
+"""
+import pytest
+
+from test.integration.conftest import make_silent_wav, run_live_server
+
+
+@pytest.fixture(scope="module")
+def base_url():
+    from ovos_stt_http_server.routers.elevenlabs_scribe import make_elevenlabs_scribe_router
+
+    def register(app, model):
+        app.include_router(make_elevenlabs_scribe_router(model))
+
+    yield from run_live_server(register)
+
+
+def test_transcribe_via_elevenlabs_sdk(base_url, tmp_path):
+    pytest.importorskip("elevenlabs")
+    from elevenlabs.client import ElevenLabs
+
+    client = ElevenLabs(api_key="ignored", base_url=f"{base_url}/elevenlabs")
+
+    wav = tmp_path / "clip.wav"
+    wav.write_bytes(make_silent_wav())
+    with open(wav, "rb") as f:
+        result = client.speech_to_text.convert(file=f, model_id="scribe_v1")
+    assert result.text == "hello world"

--- a/test/integration/test_gladia_live.py
+++ b/test/integration/test_gladia_live.py
@@ -1,0 +1,40 @@
+"""Live test: drive the Gladia v2 upload -> transcription -> poll flow against
+our /gladia router.
+
+Gladia has no official Python SDK (its API is consumed over REST), so this
+exercises the documented HTTP flow against a real running server using httpx.
+"""
+import httpx
+import pytest
+
+from test.integration.conftest import make_silent_wav, run_live_server
+
+
+@pytest.fixture(scope="module")
+def base_url():
+    from ovos_stt_http_server.routers.gladia import make_gladia_router
+
+    def register(app, model):
+        app.include_router(make_gladia_router(model))
+
+    yield from run_live_server(register)
+
+
+def test_gladia_flow(base_url, tmp_path):
+    root = f"{base_url}/gladia"
+    files = {"audio": ("clip.wav", make_silent_wav(), "audio/wav")}
+    up = httpx.post(f"{root}/v2/upload", files=files, timeout=30)
+    assert up.status_code == 200
+    audio_url = up.json()["audio_url"]
+    if audio_url.startswith("/"):
+        audio_url = f"{base_url}{audio_url}"
+
+    tx = httpx.post(f"{root}/v2/transcription", json={"audio_url": audio_url}, timeout=30)
+    assert tx.status_code == 201
+    job_id = tx.json()["id"]
+
+    res = httpx.get(f"{root}/v2/transcription/{job_id}", timeout=30)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "done"
+    assert body["result"]["transcription"]["full_transcript"] == "hello world"

--- a/test/integration/test_groq_sdk_live.py
+++ b/test/integration/test_groq_sdk_live.py
@@ -1,0 +1,32 @@
+"""Live test: drive the official Groq SDK against our /groq router.
+
+Groq's client defaults to ``https://api.groq.com`` and appends
+``/openai/v1/audio/transcriptions``; pointing ``base_url`` at ``{server}/groq``
+makes it hit our router unchanged.
+"""
+import pytest
+
+from test.integration.conftest import make_silent_wav, run_live_server
+
+
+@pytest.fixture(scope="module")
+def base_url():
+    from ovos_stt_http_server.routers.groq import make_groq_router
+
+    def register(app, model):
+        app.include_router(make_groq_router(model))
+
+    yield from run_live_server(register)
+
+
+def test_transcribe_via_groq_sdk(base_url, tmp_path):
+    groq = pytest.importorskip("groq")
+    client = groq.Groq(api_key="ignored", base_url=f"{base_url}/groq")
+
+    wav = tmp_path / "clip.wav"
+    wav.write_bytes(make_silent_wav())
+    with open(wav, "rb") as f:
+        result = client.audio.transcriptions.create(
+            file=(wav.name, f.read()), model="whisper-large-v3"
+        )
+    assert result.text == "hello world"

--- a/test/unittests/test_elevenlabs_scribe.py
+++ b/test/unittests/test_elevenlabs_scribe.py
@@ -1,0 +1,73 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the ElevenLabs Scribe-compatible router."""
+import io
+import wave
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _wav_bytes(frames: int = 160) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * frames)
+    return buf.getvalue()
+
+
+class FakeModel:
+    def process_audio(self, audio, lang: str = "auto") -> str:
+        return "hello world"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    from ovos_stt_http_server.routers.elevenlabs_scribe import make_elevenlabs_scribe_router
+    app = FastAPI()
+    app.include_router(make_elevenlabs_scribe_router(FakeModel()))
+    return TestClient(app)
+
+
+PATH = "/elevenlabs/v1/speech-to-text"
+
+
+class TestScribeRouter:
+    def test_basic(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model_id": "scribe_v1"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["text"] == "hello world"
+        assert body["language_code"] == "en"
+        assert isinstance(body["words"], list)
+
+    def test_language_code_echoed(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model_id": "scribe_v1", "language_code": "pt"})
+        assert r.status_code == 200
+        assert r.json()["language_code"] == "pt"
+
+    def test_api_key_header_accepted(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model_id": "scribe_v1"},
+                        headers={"xi-api-key": "fake"})
+        assert r.status_code == 200
+
+    def test_model_id_defaulted(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")}, data={})
+        assert r.status_code == 200
+        assert r.json()["text"] == "hello world"
+
+    def test_empty_file_400(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", b"", "audio/wav")},
+                        data={"model_id": "scribe_v1"})
+        assert r.status_code == 400
+
+    def test_raw_bytes_fallback(self, client):
+        r = client.post(PATH, files={"file": ("a.raw", b"\x00\x00" * 160, "application/octet-stream")},
+                        data={"model_id": "scribe_v1"})
+        assert r.status_code == 200
+        assert r.json()["text"] == "hello world"

--- a/test/unittests/test_gladia.py
+++ b/test/unittests/test_gladia.py
@@ -1,0 +1,74 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the Gladia-compatible router (upload -> transcription -> poll)."""
+import io
+import wave
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _wav_bytes(frames: int = 160) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * frames)
+    return buf.getvalue()
+
+
+class FakeModel:
+    def process_audio(self, audio, lang: str = "auto") -> str:
+        return "hello world"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    from ovos_stt_http_server.routers.gladia import make_gladia_router
+    app = FastAPI()
+    app.include_router(make_gladia_router(FakeModel()))
+    return TestClient(app)
+
+
+class TestGladiaRouter:
+    def test_full_flow(self, client):
+        # 1. upload
+        up = client.post("/gladia/v2/upload",
+                         files={"audio": ("a.wav", _wav_bytes(), "audio/wav")})
+        assert up.status_code == 200
+        audio_url = up.json()["audio_url"]
+        assert "/gladia/v2/upload/" in audio_url
+
+        # 2. request transcription (runs synchronously)
+        tx = client.post("/gladia/v2/transcription", json={"audio_url": audio_url})
+        assert tx.status_code == 201
+        job = tx.json()
+        assert "id" in job and "result_url" in job
+
+        # 3. poll result — already done
+        res = client.get(f"/gladia/v2/transcription/{job['id']}")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["status"] == "done"
+        assert body["result"]["transcription"]["full_transcript"] == "hello world"
+
+    def test_unknown_audio_url_404(self, client):
+        r = client.post("/gladia/v2/transcription",
+                        json={"audio_url": "/gladia/v2/upload/does-not-exist"})
+        assert r.status_code == 404
+
+    def test_unknown_job_404(self, client):
+        r = client.get("/gladia/v2/transcription/nope")
+        assert r.status_code == 404
+
+    def test_empty_upload_400(self, client):
+        r = client.post("/gladia/v2/upload",
+                        files={"audio": ("a.wav", b"", "audio/wav")})
+        assert r.status_code == 400
+
+    def test_gladia_key_header_accepted(self, client):
+        up = client.post("/gladia/v2/upload",
+                         files={"audio": ("a.wav", _wav_bytes(), "audio/wav")},
+                         headers={"x-gladia-key": "fake"})
+        assert up.status_code == 200

--- a/test/unittests/test_groq.py
+++ b/test/unittests/test_groq.py
@@ -1,0 +1,83 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the Groq-compatible router (no live server, no API key)."""
+import io
+import wave
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _wav_bytes(frames: int = 160) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * frames)
+    return buf.getvalue()
+
+
+class FakeModel:
+    def process_audio(self, audio, lang: str = "auto") -> str:
+        return "hello world"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    from ovos_stt_http_server.routers.groq import make_groq_router
+    app = FastAPI()
+    app.include_router(make_groq_router(FakeModel()))
+    return TestClient(app)
+
+
+PATH = "/groq/openai/v1/audio/transcriptions"
+
+
+class TestGroqRouter:
+    def test_json_default(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["text"] == "hello world"
+        # the x_groq block is what distinguishes Groq from plain OpenAI
+        assert "x_groq" in body and body["x_groq"]["id"].startswith("req_")
+
+    def test_text_format(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3", "response_format": "text"})
+        assert r.status_code == 200
+        assert r.text == "hello world"
+
+    def test_language_param(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3", "language": "pt"})
+        assert r.status_code == 200
+        assert r.json()["text"] == "hello world"
+
+    def test_bearer_header_accepted(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3"},
+                        headers={"Authorization": "Bearer gsk_fake"})
+        assert r.status_code == 200
+
+    def test_empty_file_400(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", b"", "audio/wav")},
+                        data={"model": "whisper-large-v3"})
+        assert r.status_code == 400
+
+    def test_missing_model_422(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")}, data={})
+        assert r.status_code == 422
+
+    def test_unknown_format_422(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3", "response_format": "xml"})
+        assert r.status_code == 422
+
+    def test_raw_bytes_fallback(self, client):
+        r = client.post(PATH, files={"file": ("a.raw", b"\x00\x00" * 160, "application/octet-stream")},
+                        data={"model": "whisper-large-v3"})
+        assert r.status_code == 200
+        assert r.json()["text"] == "hello world"


### PR DESCRIPTION
## Summary
Adds three vendor-compatible routers (symmetry with the existing 15) so clients of these STT services can be repointed at any self-hosted OVOS plugin:

| Vendor | Prefix | Endpoint |
|---|---|---|
| Groq | `/groq` | `POST /groq/openai/v1/audio/transcriptions` (OpenAI-shaped + `x_groq` block) |
| ElevenLabs Scribe | `/elevenlabs` | `POST /elevenlabs/v1/speech-to-text` (multipart) |
| Gladia | `/gladia` | `POST /v2/upload` → `POST /v2/transcription` → `GET /v2/transcription/{id}` |

Gladia's async flow is preserved on the wire but backed by a synchronous in-memory job store (OVOS engines are batch), so jobs are `done` on first poll.

## Tests
- New per-router suites (`test_groq.py`, `test_gladia.py`, `test_elevenlabs_scribe.py`) using FastAPI TestClient + fake model; no network.
- Full suite: **329 passed**.
- SDK examples added under `examples/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)