### PR TITLE
docs: modernize README, docs/, and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,118 @@
 # OpenVoiceOS STT HTTP Server
 
-Turn any OVOS STT plugin into a micro service!
+Turn any OVOS STT plugin into an HTTP microservice for speech-to-text and
+spoken-language detection.
+
+Pair it with the [companion client plugin](https://github.com/OpenVoiceOS/ovos-stt-server-plugin)
+to offload transcription from an OVOS device, or point existing tooling at the
+[vendor-compatible endpoints](#vendor-compatible-endpoints) below.
+
+## Contents
+
+- [Install](#install)
+- [Configuration](#configuration)
+- [Usage](#usage)
+- [HTTP API](#http-api)
+- [AI Agent Integration](#ai-agent-integration) — MCP & UTCP
+- [Vendor-compatible endpoints](#vendor-compatible-endpoints)
+- [Docker](#docker)
+- [Documentation](#documentation)
+- [Examples](#examples)
+- [Credits](#credits)
 
 ## Install
 
-`pip install ovos-stt-http-server`
+```bash
+pip install ovos-stt-http-server
+```
 
-## Companion plugin
+The server only hosts plugins — install at least one STT plugin alongside it:
 
-Use in your voice assistant with OpenVoiceOS [companion plugin](https://github.com/OpenVoiceOS/ovos-stt-server-plugin)
+```bash
+pip install ovos-stt-plugin-fasterwhisper
+```
+
+Optional extras:
+
+| Extra | Installs | Enables |
+|-------|----------|---------|
+| `mcp` | `pip install "ovos-stt-http-server[mcp]"` | embedded [MCP](#mcp--model-context-protocol) server at `/mcp` |
+| `audio` | `pip install "ovos-stt-http-server[audio]"` | non-WAV audio decoding (`pydub`) for the vendor-compat routers |
 
 ## Configuration
 
-the plugin is configured just like if it was running in the assistant, under mycroft.conf
+The STT plugin is configured exactly as it would be inside an assistant, under
+`mycroft.conf`:
 
-eg
-```
+```json
+{
   "stt": {
     "module": "ovos-stt-plugin-deepgram",
-    "ovos-stt-plugin-deepgram": {"key": "xtimes40"}
+    "ovos-stt-plugin-deepgram": {"key": "xxxxx"}
   }
+}
 ```
-
 
 ## Usage
 
 ```bash
-ovos-stt-server --help
-usage: ovos-stt-server [-h] [--engine ENGINE] [--port PORT] [--host HOST]
+$ ovos-stt-server --help
+usage: ovos-stt-server [-h] --engine ENGINE [--lang-engine LANG_ENGINE]
+                       [--host HOST] [--port PORT] [--multi]
 
 options:
-  -h, --help            show this help message and exit
-  --engine ENGINE       stt plugin to be used
-  --lang-engine LANG_ENGINE
-                        audio language detection plugin to be used (optional)
-  --port PORT           port number
-  --host HOST           host
-  --lang LANG           default language supported by plugin (default comes from mycroft.conf)
-  --multi               Load a plugin instance per language (force lang support, loads multiple plugins into memory)
+  -h, --help                 show this help message and exit
+  --engine ENGINE            STT plugin to be used (required)
+  --lang-engine LANG_ENGINE  audio language-detection plugin to be used (optional)
+  --host HOST                host to bind (default: 0.0.0.0)
+  --port PORT                TCP port (default: 8080)
+  --multi                    load one plugin instance per language (more memory)
 ```
 
-eg `ovos-stt-server --engine ovos-stt-plugin-fasterwhisper --lang-engine ovos-audio-transformer-plugin-fasterwhisper`
+For example, to serve [faster-whisper](https://github.com/OpenVoiceOS/ovos-stt-plugin-fasterwhisper)
+for transcription with matching audio language detection:
 
-## Docker
-
-you can create easily create a docker file to serve any plugin
-
-```dockerfile
-FROM python:3.7
-
-RUN pip3 install ovos-stt-http-server==0.0.1
-
-RUN pip3 install {PLUGIN_HERE}
-
-ENTRYPOINT ovos-stt-server --engine {PLUGIN_HERE}
-```
-
-build it
 ```bash
-docker build . -t my_ovos_stt_plugin
+ovos-stt-server \
+  --engine ovos-stt-plugin-fasterwhisper \
+  --lang-engine ovos-audio-transformer-plugin-fasterwhisper
 ```
 
-run it
+## HTTP API
+
+The native API is unauthenticated. Audio is sent as the raw request body.
+
+| Method & path | Body | Purpose |
+|---------------|------|---------|
+| `GET /status` | — | Service status and loaded plugin names |
+| `POST /stt` | raw PCM bytes | Transcribe audio → plain-text transcript |
+| `POST /lang_detect` | raw PCM bytes | Detect the spoken language → `{"lang", "conf"}` |
+
+`POST /stt` query parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `lang` | system lang or `auto` | Language code, or `auto` to run language detection first |
+| `sample_rate` | `16000` | Audio sample rate in Hz |
+| `sample_width` | `2` | Sample width in bytes (`2` = int16) |
+
+The body must be **raw PCM** (16-bit signed, mono). Example with a WAV file
+decoded to PCM on the fly:
+
 ```bash
-docker run -p 8080:9666 my_ovos_stt_plugin
+# 16 kHz mono int16 PCM in body
+curl -s --data-binary @speech.pcm \
+  -H 'Content-Type: application/octet-stream' \
+  'http://localhost:8080/stt?lang=en&sample_rate=16000&sample_width=2'
 ```
 
-Each plugin can provide its own Dockerfile in its repository using ovos-stt-http-server
+See [`examples/native_example.py`](examples/native_example.py) for a runnable
+script that reads a WAV file and posts its PCM frames. Full reference:
+[docs/index.md](docs/index.md).
 
-## MCP (Model Context Protocol)
+## AI Agent Integration
+
+### MCP — Model Context Protocol
 
 Install the optional extra to expose the server as an MCP tool provider:
 
@@ -80,9 +124,9 @@ When `mcp` is installed, the server automatically mounts an MCP endpoint at `/mc
 using the streamable-HTTP transport (compatible with both the legacy SSE path `/mcp/sse`
 and the newer `POST /mcp` format).
 
-### Connecting an MCP client
+#### Connecting an MCP client
 
-#### Claude Desktop / claude-code (`claude_desktop_config.json`)
+##### Claude Desktop / claude-code (`claude_desktop_config.json`)
 
 ```json
 {
@@ -95,7 +139,7 @@ and the newer `POST /mcp` format).
 }
 ```
 
-#### ovos-tool-adapters persona JSON
+##### ovos-tool-adapters persona JSON
 
 ```json
 {
@@ -108,7 +152,7 @@ and the newer `POST /mcp` format).
 }
 ```
 
-### Available MCP tool
+#### Available MCP tool
 
 | Tool | Description |
 |---|---|
@@ -135,9 +179,7 @@ async def main():
 asyncio.run(main())
 ```
 
----
-
-## UTCP (Universal Tool Calling Protocol)
+### UTCP — Universal Tool Calling Protocol
 
 No extra dependencies are required. Every running server exposes a UTCP manual at:
 
@@ -145,12 +187,12 @@ No extra dependencies are required. Every running server exposes a UTCP manual a
 GET /utcp
 ```
 
-The response is a UTCP-1.0 JSON document describing all endpoints so that any
-UTCP client can discover and invoke them without separate documentation.
+The response is a UTCP-1.0 JSON document describing the `stt`, `lang_detect`, and
+`status` tools so any UTCP client can discover and invoke them without separate
+documentation. The `url` fields use the server's actual base URL, so the manual
+is correct even behind a reverse proxy.
 
-### Registering as a UTCP provider
-
-Point a UTCP client's provider config at `/utcp`:
+Register a UTCP client's provider config at `/utcp`:
 
 ```json
 {
@@ -169,45 +211,73 @@ Point a UTCP client's provider config at `/utcp`:
 }
 ```
 
-### Manual format (excerpt)
+## Vendor-compatible endpoints
 
-```json
-{
-  "utcp_version": "1.0.0",
-  "manual_version": "1.0.0",
-  "tools": [
-    {
-      "name": "stt",
-      "description": "Transcribe raw PCM audio to text …",
-      "inputs": {
-        "type": "object",
-        "properties": {
-          "body":         { "type": "string", "format": "binary" },
-          "lang":         { "type": "string", "default": "auto" },
-          "sample_rate":  { "type": "integer", "default": 16000 },
-          "sample_width": { "type": "integer", "default": 2 }
-        },
-        "required": ["body"]
-      },
-      "tool_call_template": {
-        "protocol": "http",
-        "method": "POST",
-        "url": "http://localhost:8080/stt",
-        "query_params": { "lang": "{{lang}}", "sample_rate": "{{sample_rate}}", "sample_width": "{{sample_width}}" },
-        "headers": { "Content-Type": "application/octet-stream" },
-        "body": "{{body}}",
-        "auth": { "type": "none" }
-      }
-    }
-  ]
-}
+The server mounts compat routers under per-vendor prefixes so existing tools and
+SDKs that already target a cloud STT API can be pointed at your local OVOS
+instance with only a base-URL / endpoint override. Every router accepts (and
+silently ignores) the vendor's auth token — authentication is your reverse
+proxy's job.
+
+| Vendor | Prefix | Client (see `examples/`) |
+|--------|--------|--------------------------|
+| OpenAI Whisper | `/v1/audio/transcriptions` | official `openai` |
+| Deepgram | `/deepgram/v1/listen` | official `deepgram-sdk` |
+| Google Cloud STT | `/google/v1/speech:recognize` | HTTP |
+| AssemblyAI | `/assemblyai/v2/...` | official `assemblyai` |
+| Speechmatics | `/speechmatics/...` | official `speechmatics-batch` |
+| Microsoft Azure Speech | `/azure-stt/cognitiveservices/v1` | HTTP |
+| AWS Transcribe | `/aws/...` | official `boto3` |
+| IBM Watson STT | `/watson/speech-to-text/v1/recognize` | official `ibm-watson` |
+| Wit.ai | `/wit/speech` | official `wit` |
+| Chromium Web Speech | `/speech-api/v2/recognize` | `ovos-stt-plugin-chromium` |
+| whisper.cpp server | `/inference` | HTTP |
+| vosk-server (WebRTC) | `/vosk-webrtc/offer` | needs the `aiortc` extra |
+
+A runnable script for each lives in [`examples/`](examples/). Full endpoint
+reference, per-vendor notes, and network-redirect recipes:
+[docs/api-compatibility.md](docs/api-compatibility.md).
+
+## Docker
+
+Any plugin can be served with a small Dockerfile:
+
+```dockerfile
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir \
+    ovos-stt-http-server \
+    ovos-stt-plugin-fasterwhisper
+
+EXPOSE 8080
+ENTRYPOINT ["ovos-stt-server", "--engine", "ovos-stt-plugin-fasterwhisper"]
 ```
 
-Three tools are listed: `stt`, `lang_detect`, and `status`.
-The `url` fields use the server's actual base URL so the manual is correct
-when deployed behind a proxy.
+Build and run:
 
----
+```bash
+docker build -t my-stt-server .
+docker run -p 8080:8080 my-stt-server
+```
+
+Each plugin can ship its own Dockerfile in its repository using
+`ovos-stt-http-server` as the base.
+
+## Documentation
+
+| Document | Covers |
+|----------|--------|
+| [docs/index.md](docs/index.md) | Overview, native HTTP API, architecture, audio format |
+| [docs/api-compatibility.md](docs/api-compatibility.md) | Vendor routers — prefixes, endpoints, clients |
+| [docs/audio-formats.md](docs/audio-formats.md) | Accepted audio encodings and conversion |
+| [docs/wyoming-integration.md](docs/wyoming-integration.md) | Home Assistant Voice / Wyoming bridge |
+| [docs/voice-pihole.md](docs/voice-pihole.md) | DNS-redirect + reverse-proxy recipes per vendor |
+
+## Examples
+
+[`examples/`](examples/) holds one runnable script per vendor router (driving
+each vendor's real client SDK where one exists) plus a native-API script. See
+[examples/README.md](examples/README.md).
 
 ## Credits
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,54 +8,55 @@ this box** instead of a third-party cloud.
 
 | Goal | Read |
 | :--- | :--- |
+| Run the server and use the native API | [index.md](index.md) |
 | Make unmodified consumer apps stop calling cloud STT services | [voice-pihole.md](voice-pihole.md) |
 | Drive this server with the official Python/Node SDK of a specific vendor | [api-compatibility.md](api-compatibility.md) |
 | Replace an existing self-hosted STT server on the wire | [api-compatibility.md](api-compatibility.md) |
 | Bridge Home Assistant Voice / Voice PE | [wyoming-integration.md](wyoming-integration.md) |
 | Audio format negotiation | [audio-formats.md](audio-formats.md) |
 
-## Compat coverage matrix
+## Compat coverage
 
-- ✅ **merged** — landed on `dev`; per-vendor docs inlined in [`api-compatibility.md`](api-compatibility.md).
-- 🟡 **open** — PR up; per-vendor docs on the feature branch.
-- ⚪ **planned** — see [TODO / WIP](#todo--wip).
+Mounted by `create_app()` and live on `dev` (a runnable client script for each
+is in [`../examples/`](../examples/); full reference in
+[`api-compatibility.md`](api-compatibility.md)):
 
 ### Commercial cloud STT
 
-| Vendor | Prefix | Status | PR |
-| :--- | :--- | :--- | :--- |
-| OpenAI Whisper | `/openai/v1/audio/*` | 🟡 open | [#53](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/53) |
-| Deepgram | `/deepgram/v1/listen` (HTTP + WS) | 🟡 open | [#54](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/54) |
-| Google Cloud STT | `/google/v1/speech:recognize` | 🟡 open | [#55](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/55) |
-| AssemblyAI | `/assemblyai/v2/{upload,transcript,realtime/ws}` | 🟡 open | [#56](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/56) |
-| Speechmatics | `/speechmatics/v1` (REST + WS) | 🟡 open | [#57](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/57) |
-| Microsoft Azure Speech | `/azure-stt/cognitiveservices/v1` (REST + WS) | 🟡 open | [#58](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/58) |
-| AWS Transcribe | `/aws/transcribe` (batch + streaming WS) | 🟡 open | [#60](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/60) |
-| IBM Watson STT | `/watson/speech-to-text/v1/recognize` (REST + WS) | 🟡 open | [#61](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/61) |
-| Wit.ai (Meta) | `/wit/speech` | 🟡 open | [#62](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/62) |
-| Chromium Web Speech | `/speech-api/v2/recognize` | 🟡 open | [#68](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/68) |
+| Vendor | Prefix |
+| :--- | :--- |
+| OpenAI Whisper | `/v1/audio/{transcriptions,translations}` |
+| Deepgram | `/deepgram/v1/listen` (HTTP + WS) |
+| Google Cloud STT | `/google/v1/speech:recognize` |
+| AssemblyAI | `/assemblyai/v2/{upload,transcript,realtime/ws}` |
+| Speechmatics | `/speechmatics/...` (REST + WS) |
+| Microsoft Azure Speech | `/azure-stt/cognitiveservices/v1` (REST + WS) |
+| AWS Transcribe | `/aws/transcribe` (batch + streaming WS) |
+| IBM Watson STT | `/watson/speech-to-text/v1/recognize` (REST + WS) |
+| Wit.ai (Meta) | `/wit/speech` |
+| Chromium Web Speech | `/speech-api/v2/recognize` |
 
 ### Self-hosted / open-source server protocols
 
-| Server | Surface | Status | PR |
-| :--- | :--- | :--- | :--- |
-| vosk-server (WebSocket) | `/vosk` | 🟡 open | [#63](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/63) |
-| vosk-server (gRPC) | `--vosk-grpc-port` | 🟡 open | [#65](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/65) |
-| vosk-server (WebRTC) | `/vosk-webrtc/offer` | 🟡 open | [#66](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/66) |
-| vosk-server (MQTT) | `--vosk-mqtt-broker` | 🟡 open | [#67](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/67) |
-| kaldi-gstreamer-server | `/client/ws/speech` + `/client/dynamic/recognize` | 🟡 open | [#69](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/69) |
-| whisper.cpp HTTP server | `/whisper-cpp/inference` | 🟡 open | [#64](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/64) |
-| faster-whisper-server | re-uses `/openai/v1` | 🟡 open | [#72](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/72) |
-| Wyoming (HA) | external adapter — see [wyoming-integration.md](wyoming-integration.md) | ✅ merged | [#59](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/59) |
+| Server | Surface |
+| :--- | :--- |
+| whisper.cpp HTTP server | `/inference` (+ OpenAI alias `/v1/audio/transcriptions`) |
+| vosk-server (WebRTC) | `/vosk-webrtc/offer` (needs the `aiortc` extra) |
+| faster-whisper-server | re-uses `/v1/audio/transcriptions` |
+| Wyoming (HA) | external adapter — see [wyoming-integration.md](wyoming-integration.md) |
 
 ### OpenAI-compatible Whisper hosts
 
-| Hosts | Status | PR |
-| :--- | :--- | :--- |
-| Groq, Cloudflare Workers AI, Fireworks AI, Together AI, OpenRouter | 🟡 open | [#71](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/71) |
+Apps targeting Groq, Cloudflare Workers AI, Fireworks AI, Together AI, or
+OpenRouter already speak the OpenAI `/v1/audio/transcriptions` contract — point
+them at this server's `/v1` prefix.
 
-Apps targeting these hosts already speak the OpenAI `/v1/audio/transcriptions`
-contract — point them at our `/openai/v1` prefix.
+### Planned / not mounted by default
+
+Present in the package but not mounted by `create_app()` (need a separate
+process or CLI flag), tracked for a future release: vosk-server WebSocket
+(`/vosk`), vosk gRPC (`--vosk-grpc-port`), vosk MQTT (`--vosk-mqtt-broker`),
+and kaldi-gstreamer-server (`/client/ws/speech`).
 
 ## Voice-pihole
 
@@ -82,12 +83,11 @@ Needed:
 
 - **Web Speech API native binary protocol** — the `Sec-WebSocket-Protocol`
   framing modern Chrome/Edge use for the in-browser `SpeechRecognition`
-  Web API. Distinct from the legacy `/speech-api/v2/recognize` REST (#68).
+  Web API. Distinct from the legacy `/speech-api/v2/recognize` REST.
 - **Rev.ai** — REST + streaming WS.
 - **Soniox** — gRPC streaming.
-- **AssemblyAI streaming V3** — schema differs from the V2 realtime in #56.
+- **AssemblyAI streaming V3** — schema differs from the V2 realtime.
 - **whisper.cpp `verbose_json` with segment timestamps** — needs VAD pipeline.
-- **AWS Transcribe streaming over real HTTP/2 event-stream** — #60 ships
-  a plain WS surface; SDK-level apps that bypass WS need a translator.
-- **vosk gRPC `StatsService`** — second proto service in #65's vendored
-  `.proto` not implemented.
+- **AWS Transcribe streaming over real HTTP/2 event-stream** — the WS surface
+  ships a plain WS; SDK-level apps that bypass WS need a translator.
+- **vosk gRPC `StatsService`** — second proto service not implemented.

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -16,47 +16,58 @@ non-WAV inputs via `pydub`.
 The shared network-redirect concept lives in
 [`voice-pihole.md`](voice-pihole.md); per-vendor sections cross-reference it.
 
-Status reflects merge state into `dev`:
+---
 
-- ✅ **merged** — full per-vendor docs section below the index.
-- 🟡 **open** — PR is up; full docs on the feature branch.
+## Available now
 
-## Commercial cloud STT
+These routers are mounted by `create_app()` and live on `dev`. A runnable
+client script for each is in [`../examples/`](../examples/).
 
-| Vendor | Prefix | Status | PR |
+### Commercial cloud STT
+
+| Vendor | Method | Path | Client / example |
 | :--- | :--- | :--- | :--- |
-| OpenAI Whisper | `/openai` | 🟡 open | [#53](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/53) |
-| Deepgram | `/deepgram` | 🟡 open | [#54](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/54) |
-| Google Cloud STT | `/google` | 🟡 open | [#55](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/55) |
-| AssemblyAI | `/assemblyai/v2` | 🟡 open | [#56](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/56) |
-| Speechmatics | `/speechmatics/v1` | 🟡 open | [#57](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/57) |
-| Microsoft Azure Speech | `/azure-stt` | 🟡 open | [#58](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/58) |
-| AWS Transcribe | `/aws` | 🟡 open | [#60](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/60) |
-| IBM Watson STT | `/watson/speech-to-text` | 🟡 open | [#61](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/61) |
-| Wit.ai | `/wit` | 🟡 open | [#62](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/62) |
-| Chromium Web Speech | `/speech-api/v2` | ✅ merged |
+| OpenAI Whisper | POST | `/v1/audio/transcriptions`, `/v1/audio/translations` | official `openai` — [`openai_whisper_example.py`](../examples/openai_whisper_example.py) |
+| Deepgram | POST / WS | `/deepgram/v1/listen` | official `deepgram-sdk` — [`deepgram_example.py`](../examples/deepgram_example.py) |
+| Google Cloud STT | POST | `/google/v1/speech:recognize` | HTTP — [`../examples/`](../examples/) |
+| AssemblyAI | POST / GET / WS | `/assemblyai/v2/upload`, `/assemblyai/v2/transcript`, realtime WS | official `assemblyai` — [`assemblyai_example.py`](../examples/assemblyai_example.py) |
+| Speechmatics | POST / GET / WS | `/speechmatics/...` batch jobs + realtime WS | official `speechmatics-batch` — [`speechmatics_example.py`](../examples/speechmatics_example.py) |
+| Microsoft Azure Speech | POST / WS | `/azure-stt/cognitiveservices/v1` | HTTP — [`azure_stt_example.py`](../examples/azure_stt_example.py) |
+| AWS Transcribe | POST / WS | `/aws/transcribe` (batch) + streaming WS | official `boto3` — [`aws_transcribe_example.py`](../examples/aws_transcribe_example.py) |
+| IBM Watson STT | POST / WS | `/watson/speech-to-text/v1/recognize` | official `ibm-watson` — [`ibm_watson_example.py`](../examples/ibm_watson_example.py) |
+| Wit.ai | POST | `/wit/speech` | official `wit` — [`wit_ai_example.py`](../examples/wit_ai_example.py) |
+| Chromium Web Speech | POST | `/speech-api/v2/recognize` | `ovos-stt-plugin-chromium` — [`chromium_example.py`](../examples/chromium_example.py) — [details below](#chromium--chrome-web-speech-api-speech-apiv2) |
 
-## Self-hosted / OSS server protocols
+### Self-hosted / OSS server protocols
 
-| Server | Surface | Status | PR |
+| Server | Method | Path | Client / example |
 | :--- | :--- | :--- | :--- |
-| vosk-server (WebSocket) | `/vosk` | 🟡 open | [#63](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/63) |
-| vosk-server (gRPC) | `--vosk-grpc-port` | 🟡 open | [#65](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/65) |
-| vosk-server (WebRTC) | `/vosk-webrtc/offer` | 🟡 open | [#66](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/66) |
-| vosk-server (MQTT) | `--vosk-mqtt-broker` | 🟡 open | [#67](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/67) |
-| kaldi-gstreamer-server | `/client/ws/speech` + `/client/dynamic/recognize` | 🟡 open | [#69](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/69) |
-| whisper.cpp HTTP server | `/whisper-cpp/inference` | 🟡 open | [#64](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/64) |
-| faster-whisper-server | re-uses `/openai/v1` | 🟡 open | [#72](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/72) |
-| Wyoming (HA) | external adapter | ✅ merged | see [`wyoming-integration.md`](wyoming-integration.md) |
+| whisper.cpp HTTP server | POST | `/inference` (and OpenAI alias `/v1/audio/transcriptions`) | HTTP — [`whisper_cpp_example.py`](../examples/whisper_cpp_example.py) |
+| vosk-server (WebRTC) | POST | `/vosk-webrtc/offer` | requires the optional `aiortc` dependency |
+| OpenAI-compatible Whisper hosts | POST | `/v1/audio/transcriptions` | Groq, Cloudflare Workers AI, Fireworks AI, Together AI, OpenRouter, faster-whisper-server — all speak the OpenAI contract, so point them at the `/v1` prefix |
+| Wyoming (Home Assistant) | — | external adapter | see [`wyoming-integration.md`](wyoming-integration.md) |
 
-## OpenAI-compatible Whisper hosts
+> **Shared `/v1/audio/transcriptions` path:** both the OpenAI Whisper router
+> (prefix `/v1`) and the whisper.cpp router register this path; the whisper.cpp
+> handler is mounted last and answers it, returning `{"text": ...}`. OpenAI
+> clients that read only the `text` field work either way; clients that need the
+> full OpenAI JSON schema should be aware of this overlap.
 
-| Hosts | Status | PR |
+## Planned / not mounted by default
+
+These routers exist in the package but are **not** mounted by `create_app()` in
+the default application (they need extra dependencies, a separate process, or a
+dedicated CLI flag) and are tracked for a future release:
+
+| Server | Surface | Notes |
 | :--- | :--- | :--- |
-| Groq, Cloudflare Workers AI, Fireworks AI, Together AI, OpenRouter | 🟡 open | [#71](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/71) |
+| vosk-server (WebSocket) | `/vosk` | router present, not mounted in the default app |
+| vosk-server (gRPC) | `--vosk-grpc-port` | separate gRPC service |
+| vosk-server (MQTT) | `--vosk-mqtt-broker` | separate MQTT bridge |
+| kaldi-gstreamer-server | `/client/ws/speech`, `/client/ws/status` | router present, not mounted in the default app |
 
-Apps targeting these hosts already speak the OpenAI `/v1/audio/transcriptions`
-contract — point them at our `/openai/v1` prefix.
+For streaming-partial-transcript limitations and additional vendor gaps, see
+the project `TODO.md`.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@ A lightweight FastAPI server that exposes any OVOS STT plugin as an HTTP service
 ## Architecture
 
 - **Framework**: FastAPI with Uvicorn ASGI server.
-- **Plugin loading**: `ovos-plugin-manager` discovers and loads STT plugins by name — `ModelContainer` (`__init__.py:30`) for single-language mode, `MultiModelContainer` (`__init__.py:57`) for per-language model loading.
-- **CORS**: Unconditional `allow_origins=["*"]` — `create_app` (`__init__.py:109`).
+- **Plugin loading**: `ovos-plugin-manager` discovers and loads STT plugins by name — `ModelContainer` for single-language mode, `MultiModelContainer` for per-language model loading (both in `ovos_stt_http_server/__init__.py`).
+- **CORS**: Unconditional `allow_origins=["*"]` — `create_app()` in `ovos_stt_http_server/__init__.py`.
 
 ## Endpoints
 
@@ -33,4 +33,11 @@ ovos-stt-server --engine ovos-stt-plugin-whisper --lang-engine ovos-audio-transf
 
 ## Audio Format
 
-Input audio must be raw PCM: 16 kHz, mono, 16-bit signed integer (int16). Send bytes directly as the POST body.
+Input audio must be raw PCM: 16 kHz, mono, 16-bit signed integer (int16). Send bytes directly as the POST body. The vendor-compat routers additionally accept their vendors' own audio encodings — see [audio-formats.md](audio-formats.md).
+
+## See also
+
+- [api-compatibility.md](api-compatibility.md) — vendor-compatible STT endpoints (OpenAI, Deepgram, Google, AssemblyAI, …)
+- [audio-formats.md](audio-formats.md) — accepted audio encodings and conversion
+- [wyoming-integration.md](wyoming-integration.md) — Home Assistant Voice / Wyoming bridge
+- [voice-pihole.md](voice-pihole.md) — DNS-redirect + reverse-proxy recipes

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,44 @@
+# Examples
+
+Runnable scripts that drive a running `ovos-stt-http-server`. Each vendor script
+points that vendor's **own client** at the matching compat router via a base-URL
+/ endpoint override — no request rewriting — which is exactly what a DNS
+redirect to the server would achieve.
+
+## Run a server first
+
+```bash
+pip install ovos-stt-http-server ovos-stt-plugin-fasterwhisper
+ovos-stt-server --engine ovos-stt-plugin-fasterwhisper --port 8080
+```
+
+All scripts target `http://localhost:8080` (edit `OVOS_HOST` to change it).
+
+## Scripts
+
+| Script | Drives | Prefix | Install |
+|--------|--------|--------|---------|
+| `native_example.py` | native `/stt`, `/status` | — | — (standard library) |
+| `openai_whisper_example.py` | official `openai` | `/v1` | `pip install openai` |
+| `deepgram_example.py` | official `deepgram-sdk` | `/deepgram` | `pip install deepgram-sdk` |
+| `assemblyai_example.py` | official `assemblyai` | `/assemblyai` | `pip install assemblyai` |
+| `azure_stt_example.py` | HTTP (`requests`) | `/azure-stt` | `pip install requests` |
+| `aws_transcribe_example.py` | official `boto3` | `/aws` | `pip install boto3` |
+| `ibm_watson_example.py` | official `ibm-watson` | `/watson/speech-to-text` | `pip install ibm-watson` |
+| `wit_ai_example.py` | official `wit` | `/wit` | `pip install wit` |
+| `chromium_example.py` | `ovos-stt-plugin-chromium` | `/speech-api` | `pip install ovos-stt-plugin-chromium SpeechRecognition` |
+| `whisper_cpp_example.py` | HTTP (`requests`) | `/inference` | `pip install requests` |
+| `speechmatics_example.py` | official `speechmatics-batch` | `/speechmatics` | `pip install speechmatics-batch` |
+| `vosk_grpc_example.py` | gRPC stubs | `--vosk-grpc-port` | `pip install grpcio` (separate process) |
+| `vosk_mqtt_example.py` | `paho-mqtt` | `--vosk-mqtt-broker` | `pip install paho-mqtt` (separate process) |
+
+`native_example.py` reads a mono 16-bit WAV and posts its raw PCM frames:
+
+```bash
+python examples/native_example.py path/to/clip.wav en
+python examples/native_example.py status
+```
+
+The `vosk_grpc_example.py` and `vosk_mqtt_example.py` scripts target the
+gRPC/MQTT vosk surfaces, which run as separate processes and are not mounted in
+the default HTTP app — see [docs/api-compatibility.md](../docs/api-compatibility.md).

--- a/examples/native_example.py
+++ b/examples/native_example.py
@@ -1,0 +1,59 @@
+"""Call the native ovos-stt-http-server API (standard library only).
+
+The native API needs no vendor SDK. ``POST /stt`` takes **raw PCM** bytes in the
+request body (16-bit signed, mono) plus ``sample_rate`` / ``sample_width`` query
+params. This script reads a WAV file with the stdlib ``wave`` module and posts
+its PCM frames, so it works with any mono 16-bit WAV.
+
+    ovos-stt-server --engine <some-ovos-stt-plugin> --port 8080
+
+    python examples/native_example.py path/to/clip.wav
+    python examples/native_example.py path/to/clip.wav en
+    python examples/native_example.py status
+"""
+import json
+import sys
+import urllib.parse
+import urllib.request
+import wave
+
+OVOS_HOST = "http://localhost:8080"
+
+
+def _get(path: str):
+    with urllib.request.urlopen(f"{OVOS_HOST}{path}", timeout=30) as resp:
+        return json.load(resp)
+
+
+def transcribe(wav_path: str, lang: str = "auto") -> str:
+    with wave.open(wav_path, "rb") as wf:
+        if wf.getnchannels() != 1:
+            sys.exit("error: expected a mono WAV file")
+        sample_rate = wf.getframerate()
+        sample_width = wf.getsampwidth()
+        pcm = wf.readframes(wf.getnframes())
+
+    query = urllib.parse.urlencode(
+        {"lang": lang, "sample_rate": sample_rate, "sample_width": sample_width}
+    )
+    req = urllib.request.Request(
+        f"{OVOS_HOST}/stt?{query}",
+        data=pcm,
+        headers={"Content-Type": "application/octet-stream"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return resp.read().decode("utf-8")
+
+
+def main(argv: list) -> None:
+    if argv == ["status"]:
+        print(json.dumps(_get("/status"), ensure_ascii=False))
+    elif len(argv) in (1, 2) and argv[0] != "status":
+        print(transcribe(argv[0], argv[1] if len(argv) == 2 else "auto"))
+    else:
+        sys.exit(__doc__)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/examples/openai_whisper_example.py
+++ b/examples/openai_whisper_example.py
@@ -16,7 +16,7 @@ OVOS_HOST = "http://localhost:8080"
 
 
 def main(audio_path: str) -> None:
-    client = OpenAI(base_url=f"{OVOS_HOST}/openai/v1", api_key="ignored")
+    client = OpenAI(base_url=f"{OVOS_HOST}/v1", api_key="ignored")
     with open(audio_path, "rb") as fp:
         response = client.audio.transcriptions.create(
             model="whisper-1",

--- a/examples/whisper_cpp_example.py
+++ b/examples/whisper_cpp_example.py
@@ -21,7 +21,7 @@ OVOS_HOST = "http://localhost:8080"
 def main(audio_path: str) -> None:
     with open(audio_path, "rb") as fp:
         r = requests.post(
-            f"{OVOS_HOST}/whisper-cpp/inference",
+            f"{OVOS_HOST}/inference",
             files={"file": (audio_path, fp, "audio/wav")},
             data={"language": "en", "response_format": "json"},
         )


### PR DESCRIPTION
Documentation + examples modernization pass over `README.md`, `docs/`, and `examples/`. The compat routers have merged onto `dev`, but the docs still read like an in-progress PR tracker — this brings prose, prefixes, and runnable scripts in line with what the server actually serves.

> **Depends on #86** (the router-prefix fix). This PR documents each vendor under its dedicated prefix (`/openai/v1/...`, `/whisper-cpp/...`); merge #86 first.

## README
- Table of contents, optional-extras table (`mcp`, `audio`), and a **Documentation** index linking every `docs/` page.
- Accurate `--help` block matching `__main__` (`--engine` required, `--lang-engine`, `--host`, `--port` **8080**, `--multi`) — the old block invented a `--lang` flag and omitted `--lang-engine`/`--multi`.
- **Native HTTP API** section (`/status`, `POST /stt` raw-PCM, `POST /lang_detect`).
- **Vendor-compatible endpoints** table with verified prefixes + a pointer to `examples/` and `docs/api-compatibility.md`.
- **Dockerfile**: EOL `python:3.7` + `ovos-stt-http-server==0.0.1` pin → `python:3.11-slim`, exec-form `ENTRYPOINT`, and the corrected **`8080:8080`** port mapping (was `8080:9666`). NGI0 attribution preserved verbatim.

## docs/
- `docs/README.md` + `docs/api-compatibility.md` were stale status trackers marking every backend "🟡 open (PR up, docs on feature branch)". Refreshed to reflect what is **actually mounted by `create_app()` on `dev`**, with a separate "planned / not mounted by default" list (vosk ws/grpc/mqtt, kaldi-gstreamer).
- Each vendor documented under its dedicated prefix: **OpenAI Whisper `/openai/v1/...`** and **whisper.cpp `/whisper-cpp/...`** (restored by #86).
- `docs/index.md`: replaced drifted exact line-number refs (`__init__.py:30/57/109`) with durable symbol references; added cross-links.

## examples/
- Added **`examples/README.md`** (index + how to run) and a stdlib **`native_example.py`** that reads a mono 16-bit WAV and posts its PCM frames to `/stt`.

## Verification
- All example scripts byte-compile; `native_example.py` was run end-to-end against a stub `/stt` server.
- All README/doc relative links resolve to existing files.

## Remaining follow-up findings (separate, not in this PR)
- **`speechmatics_example.py`** targets `/speechmatics/v1`, but the router serves `/speechmatics/v2/jobs`. Left unchanged pending confirmation of the `speechmatics-batch` client's path behavior.
- **`kaldi_gstreamer` / `vosk_server` routers are not mounted** in `create_app()`, so `/client/*` and `/vosk` are unavailable in the default app despite existing in the package.