### PR TITLE
fix: give the OpenAI and whisper.cpp routers dedicated vendor prefixes

### DIFF
--- a/ovos_stt_http_server/routers/openai_whisper.py
+++ b/ovos_stt_http_server/routers/openai_whisper.py
@@ -1,9 +1,9 @@
 # Licensed under the Apache License, Version 2.0
 """OpenAI Whisper-compatible STT endpoints.
 
-Implements ``POST /v1/audio/transcriptions`` (and ``/v1/audio/translations``)
-using the multipart/form-data wire format sent by the official ``openai``
-Python SDK (``openai>=1.0``).
+Implements ``POST /openai/v1/audio/transcriptions`` (and
+``/openai/v1/audio/translations``) using the multipart/form-data wire format
+sent by the official ``openai`` Python SDK (``openai>=1.0``).
 
 Usage::
 
@@ -13,7 +13,7 @@ Usage::
 Then point the SDK at the server::
 
     from openai import OpenAI
-    client = OpenAI(api_key="ignored", base_url="http://localhost:8080/v1")
+    client = OpenAI(api_key="ignored", base_url="http://localhost:8080/openai/v1")
     result = client.audio.transcriptions.create(file=audio_bytes, model="whisper-1")
 """
 import io
@@ -103,8 +103,8 @@ def make_openai_whisper_router(model, translator=None) -> APIRouter:
     """Create an OpenAI Whisper-compatible router and attach it to *model*.
 
     The router exposes:
-    - ``POST /v1/audio/transcriptions`` — transcribe audio to text.
-    - ``POST /v1/audio/translations`` — transcribe, then translate to English.
+    - ``POST /openai/v1/audio/transcriptions`` — transcribe audio to text.
+    - ``POST /openai/v1/audio/translations`` — transcribe, then translate to English.
 
     Both endpoints accept ``multipart/form-data`` with at least ``file`` and
     ``model`` fields, exactly as sent by the official ``openai`` Python SDK.
@@ -119,9 +119,9 @@ def make_openai_whisper_router(model, translator=None) -> APIRouter:
             ``None``, the transcript is returned untranslated.
 
     Returns:
-        Configured :class:`~fastapi.APIRouter` prefixed with ``/v1``.
+        Configured :class:`~fastapi.APIRouter` prefixed with ``/openai``.
     """
-    router = APIRouter(prefix="/v1", tags=["openai-whisper"])
+    router = APIRouter(prefix="/openai", tags=["openai-whisper"])
 
     async def _transcribe(
         file: UploadFile,
@@ -211,7 +211,7 @@ def make_openai_whisper_router(model, translator=None) -> APIRouter:
         )
 
     @router.post(
-        "/audio/transcriptions",
+        "/v1/audio/transcriptions",
         summary="Transcribe audio (OpenAI Whisper-compatible)",
     )
     async def transcriptions(
@@ -249,7 +249,7 @@ def make_openai_whisper_router(model, translator=None) -> APIRouter:
         return await _transcribe(file, language, response_format or "json", temperature or 0.0)
 
     @router.post(
-        "/audio/translations",
+        "/v1/audio/translations",
         summary="Translate audio to English (OpenAI Whisper-compatible)",
     )
     async def translations(

--- a/ovos_stt_http_server/routers/whisper_cpp_server.py
+++ b/ovos_stt_http_server/routers/whisper_cpp_server.py
@@ -4,11 +4,15 @@
 Emulates the HTTP API of the official ``whisper.cpp`` server binary
 (https://github.com/ggerganov/whisper.cpp/tree/master/examples/server).
 
-Two endpoints are exposed, exactly matching the upstream server paths:
+The router is mounted under the ``/whisper-cpp`` prefix so it owns a unique
+URL namespace like every other vendor router — in particular this keeps its
+OpenAI-compatible alias from colliding with the dedicated OpenAI Whisper
+router (which owns ``/v1``). Relative to that prefix it exposes the two
+upstream whisper.cpp server paths:
 
-* ``POST /inference`` — native whisper.cpp multipart endpoint.
-* ``POST /v1/audio/transcriptions`` — OpenAI-compatible endpoint;
-  semantically identical to ``/inference``.
+* ``POST /whisper-cpp/inference`` — native whisper.cpp multipart endpoint.
+* ``POST /whisper-cpp/v1/audio/transcriptions`` — OpenAI-compatible endpoint;
+  semantically identical to ``/whisper-cpp/inference``.
 
 Both accept ``multipart/form-data`` with at minimum a ``file`` field.
 Extra form fields (``temperature``, ``response_format``, ``language``,
@@ -48,12 +52,12 @@ class WhisperCppResponse(BaseModel):
 def make_whisper_cpp_server_router(model) -> APIRouter:
     """Create an ``APIRouter`` that emulates the whisper.cpp HTTP server API.
 
-    The router exposes two endpoints at the exact paths used by the upstream
-    ``whisper.cpp`` server so that any client already pointed at a real
-    whisper.cpp server works against this router without modification:
+    The router uses the upstream ``whisper.cpp`` server's own paths under the
+    ``/whisper-cpp`` prefix, so a client pointed at a real whisper.cpp server
+    works against this router by changing only its base URL to ``…/whisper-cpp``:
 
-    * ``POST /inference`` — native multipart inference endpoint.
-    * ``POST /v1/audio/transcriptions`` — OpenAI-compatible alias.
+    * ``POST /whisper-cpp/inference`` — native multipart inference endpoint.
+    * ``POST /whisper-cpp/v1/audio/transcriptions`` — OpenAI-compatible alias.
 
     Args:
         model: Any object that exposes
@@ -64,7 +68,7 @@ def make_whisper_cpp_server_router(model) -> APIRouter:
         Configured ``APIRouter`` ready to pass to
         ``app.include_router(...)``.
     """
-    router = APIRouter(tags=["whisper-cpp-server"])
+    router = APIRouter(prefix="/whisper-cpp", tags=["whisper-cpp-server"])
 
     async def _transcribe(
         file: UploadFile,

--- a/test/integration/test_whisper_cpp_live.py
+++ b/test/integration/test_whisper_cpp_live.py
@@ -34,44 +34,44 @@ def _post_wav(url: str, **form_data) -> requests.Response:
 
 
 class TestInferenceLive:
-    """Live HTTP tests for ``POST /inference``."""
+    """Live HTTP tests for ``POST /whisper-cpp/inference``."""
 
     def test_basic_transcription(self, base_url):
         """Basic WAV upload returns 'hello world' transcript."""
-        r = _post_wav(f"{base_url}/inference")
+        r = _post_wav(f"{base_url}/whisper-cpp/inference")
         r.raise_for_status()
         assert r.json() == {"text": "hello world"}
 
     def test_language_param(self, base_url):
         """language= form field is forwarded without error."""
-        r = _post_wav(f"{base_url}/inference", language="de")
+        r = _post_wav(f"{base_url}/whisper-cpp/inference", language="de")
         r.raise_for_status()
         assert r.json()["text"] == "hello world"
 
     def test_response_format_text(self, base_url):
         """response_format=text returns plain transcript."""
-        r = _post_wav(f"{base_url}/inference", response_format="text")
+        r = _post_wav(f"{base_url}/whisper-cpp/inference", response_format="text")
         r.raise_for_status()
         assert r.text == "hello world"
 
 
 class TestOpenAITranscriptionsLive:
-    """Live HTTP tests for ``POST /v1/audio/transcriptions``."""
+    """Live HTTP tests for ``POST /whisper-cpp/v1/audio/transcriptions``."""
 
     def test_basic_transcription(self, base_url):
         """Basic WAV upload returns 'hello world' transcript."""
-        r = _post_wav(f"{base_url}/v1/audio/transcriptions")
+        r = _post_wav(f"{base_url}/whisper-cpp/v1/audio/transcriptions")
         r.raise_for_status()
         assert r.json() == {"text": "hello world"}
 
     def test_model_field(self, base_url):
         """model= form field (OpenAI convention) is accepted."""
-        r = _post_wav(f"{base_url}/v1/audio/transcriptions", model="whisper-1")
+        r = _post_wav(f"{base_url}/whisper-cpp/v1/audio/transcriptions", model="whisper-1")
         r.raise_for_status()
         assert r.json()["text"] == "hello world"
 
     def test_response_format_text(self, base_url):
         """response_format=text returns plain transcript."""
-        r = _post_wav(f"{base_url}/v1/audio/transcriptions", response_format="text")
+        r = _post_wav(f"{base_url}/whisper-cpp/v1/audio/transcriptions", response_format="text")
         r.raise_for_status()
         assert r.text == "hello world"

--- a/test/unittests/test_openai_whisper.py
+++ b/test/unittests/test_openai_whisper.py
@@ -53,12 +53,12 @@ def client() -> TestClient:
 # ---------------------------------------------------------------------------
 
 class TestTranscriptions:
-    """Tests for POST /v1/audio/transcriptions."""
+    """Tests for POST /openai/v1/audio/transcriptions."""
 
     def test_json_response_default(self, client):
         """Default response_format=json returns {text: ...}."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1"},
         )
@@ -69,7 +69,7 @@ class TestTranscriptions:
     def test_json_response_explicit(self, client):
         """Explicit response_format=json returns {text: ...}."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1", "response_format": "json"},
         )
@@ -79,7 +79,7 @@ class TestTranscriptions:
     def test_text_response_format(self, client):
         """response_format=text returns plain text."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1", "response_format": "text"},
         )
@@ -89,7 +89,7 @@ class TestTranscriptions:
     def test_verbose_json_response_format(self, client):
         """response_format=verbose_json includes duration, language, segments."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1", "response_format": "verbose_json"},
         )
@@ -104,7 +104,7 @@ class TestTranscriptions:
     def test_srt_response_format(self, client):
         """response_format=srt returns SRT-formatted plain text."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1", "response_format": "srt"},
         )
@@ -115,7 +115,7 @@ class TestTranscriptions:
     def test_vtt_response_format(self, client):
         """response_format=vtt returns WebVTT-formatted plain text."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1", "response_format": "vtt"},
         )
@@ -126,7 +126,7 @@ class TestTranscriptions:
     def test_with_language_param(self, client):
         """language param is forwarded to the model."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1", "language": "pt"},
         )
@@ -136,7 +136,7 @@ class TestTranscriptions:
     def test_with_temperature_and_prompt(self, client):
         """temperature and prompt are accepted without error."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={
                 "model": "whisper-1",
@@ -149,7 +149,7 @@ class TestTranscriptions:
     def test_empty_file_returns_400(self, client):
         """Empty file body returns HTTP 400."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", b"", "audio/wav")},
             data={"model": "whisper-1"},
         )
@@ -158,7 +158,7 @@ class TestTranscriptions:
     def test_missing_model_field_returns_422(self, client):
         """Missing required model field returns HTTP 422."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={},
         )
@@ -167,7 +167,7 @@ class TestTranscriptions:
     def test_unknown_response_format_returns_422(self, client):
         """Unknown response_format returns HTTP 422."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1", "response_format": "xml"},
         )
@@ -176,7 +176,7 @@ class TestTranscriptions:
     def test_raw_bytes_fallback(self, client):
         """Non-WAV bytes (raw PCM) are accepted via fallback path."""
         resp = client.post(
-            "/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
             files={"file": ("audio.raw", b"\x00\x00" * 160, "application/octet-stream")},
             data={"model": "whisper-1"},
         )
@@ -189,12 +189,12 @@ class TestTranscriptions:
 # ---------------------------------------------------------------------------
 
 class TestTranslations:
-    """Tests for POST /v1/audio/translations."""
+    """Tests for POST /openai/v1/audio/translations."""
 
     def test_json_response(self, client):
         """translations endpoint returns {text: ...} with json format."""
         resp = client.post(
-            "/v1/audio/translations",
+            "/openai/v1/audio/translations",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1"},
         )
@@ -204,7 +204,7 @@ class TestTranslations:
     def test_text_response_format(self, client):
         """translations endpoint supports response_format=text."""
         resp = client.post(
-            "/v1/audio/translations",
+            "/openai/v1/audio/translations",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1", "response_format": "text"},
         )
@@ -214,7 +214,7 @@ class TestTranslations:
     def test_verbose_json_response_format(self, client):
         """translations endpoint supports verbose_json."""
         resp = client.post(
-            "/v1/audio/translations",
+            "/openai/v1/audio/translations",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={"model": "whisper-1", "response_format": "verbose_json"},
         )
@@ -226,7 +226,7 @@ class TestTranslations:
     def test_empty_file_returns_400(self, client):
         """translations endpoint rejects empty files."""
         resp = client.post(
-            "/v1/audio/translations",
+            "/openai/v1/audio/translations",
             files={"file": ("audio.wav", b"", "audio/wav")},
             data={"model": "whisper-1"},
         )
@@ -235,7 +235,7 @@ class TestTranslations:
     def test_missing_model_returns_422(self, client):
         """Missing model field returns 422."""
         resp = client.post(
-            "/v1/audio/translations",
+            "/openai/v1/audio/translations",
             files={"file": ("audio.wav", _wav_bytes(), "audio/wav")},
             data={},
         )
@@ -262,7 +262,7 @@ def test_translations_runs_through_translator():
     import io
     c = _client_with_translator()
     resp = c.post(
-        "/v1/audio/translations",
+        "/openai/v1/audio/translations",
         files={"file": ("a.wav", io.BytesIO(b"RIFFxxxx"), "audio/wav")},
         data={"model": "whisper-1"},
     )
@@ -280,7 +280,7 @@ def test_translations_without_translator_returns_transcript():
     app.include_router(make_openai_whisper_router(FakeModel()))  # translator=None
     c = TestClient(app)
     resp = c.post(
-        "/v1/audio/translations",
+        "/openai/v1/audio/translations",
         files={"file": ("a.wav", io.BytesIO(b"RIFFxxxx"), "audio/wav")},
         data={"model": "whisper-1"},
     )

--- a/test/unittests/test_whisper_cpp_server.py
+++ b/test/unittests/test_whisper_cpp_server.py
@@ -76,22 +76,22 @@ def wav() -> bytes:
 
 
 # ---------------------------------------------------------------------------
-# /inference tests
+# /whisper-cpp/inference tests
 # ---------------------------------------------------------------------------
 
 class TestInferenceEndpoint:
-    """Tests for the native whisper.cpp ``POST /inference`` endpoint."""
+    """Tests for the native whisper.cpp ``POST /whisper-cpp/inference`` endpoint."""
 
     def test_returns_transcript_json(self, client, wav):
         """Happy path: WAV upload returns JSON with transcribed text."""
-        r = client.post("/inference", files={"file": ("audio.wav", wav, "audio/wav")})
+        r = client.post("/whisper-cpp/inference", files={"file": ("audio.wav", wav, "audio/wav")})
         assert r.status_code == 200
         assert r.json() == {"text": "hello world"}
 
     def test_response_format_json_explicit(self, client, wav):
         """Explicit response_format=json returns the same JSON body."""
         r = client.post(
-            "/inference",
+            "/whisper-cpp/inference",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"response_format": "json"},
         )
@@ -101,7 +101,7 @@ class TestInferenceEndpoint:
     def test_response_format_text(self, client, wav):
         """response_format=text returns plain text transcript."""
         r = client.post(
-            "/inference",
+            "/whisper-cpp/inference",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"response_format": "text"},
         )
@@ -111,7 +111,7 @@ class TestInferenceEndpoint:
     def test_language_param_accepted(self, client, wav):
         """language= form field is accepted without error."""
         r = client.post(
-            "/inference",
+            "/whisper-cpp/inference",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"language": "de"},
         )
@@ -121,7 +121,7 @@ class TestInferenceEndpoint:
     def test_temperature_param_accepted(self, client, wav):
         """temperature= form field is accepted and silently ignored."""
         r = client.post(
-            "/inference",
+            "/whisper-cpp/inference",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"temperature": "0.2"},
         )
@@ -130,7 +130,7 @@ class TestInferenceEndpoint:
     def test_prompt_param_accepted(self, client, wav):
         """prompt= form field is accepted and silently ignored."""
         r = client.post(
-            "/inference",
+            "/whisper-cpp/inference",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"prompt": "some hint"},
         )
@@ -139,7 +139,7 @@ class TestInferenceEndpoint:
     def test_translate_param_accepted(self, client, wav):
         """translate= form field is accepted and silently ignored."""
         r = client.post(
-            "/inference",
+            "/whisper-cpp/inference",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"translate": "false"},
         )
@@ -148,7 +148,7 @@ class TestInferenceEndpoint:
     def test_empty_transcript_returns_empty_text(self, empty_client, wav):
         """Empty model transcript surfaces as empty 'text' field."""
         r = empty_client.post(
-            "/inference",
+            "/whisper-cpp/inference",
             files={"file": ("audio.wav", wav, "audio/wav")},
         )
         assert r.status_code == 200
@@ -156,21 +156,21 @@ class TestInferenceEndpoint:
 
     def test_missing_file_returns_422(self, client):
         """No file field → FastAPI validation error 422."""
-        r = client.post("/inference", data={"language": "en"})
+        r = client.post("/whisper-cpp/inference", data={"language": "en"})
         assert r.status_code == 422
 
 
 # ---------------------------------------------------------------------------
-# /v1/audio/transcriptions tests
+# /whisper-cpp/v1/audio/transcriptions tests
 # ---------------------------------------------------------------------------
 
 class TestOpenAITranscriptionsEndpoint:
-    """Tests for the OpenAI-compatible ``POST /v1/audio/transcriptions``."""
+    """Tests for the OpenAI-compatible ``POST /whisper-cpp/v1/audio/transcriptions``."""
 
     def test_returns_transcript_json(self, client, wav):
         """Happy path: WAV upload returns JSON with transcribed text."""
         r = client.post(
-            "/v1/audio/transcriptions",
+            "/whisper-cpp/v1/audio/transcriptions",
             files={"file": ("audio.wav", wav, "audio/wav")},
         )
         assert r.status_code == 200
@@ -179,7 +179,7 @@ class TestOpenAITranscriptionsEndpoint:
     def test_model_field_accepted(self, client, wav):
         """model= form field (OpenAI convention) is accepted without error."""
         r = client.post(
-            "/v1/audio/transcriptions",
+            "/whisper-cpp/v1/audio/transcriptions",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"model": "whisper-1"},
         )
@@ -189,7 +189,7 @@ class TestOpenAITranscriptionsEndpoint:
     def test_language_param_accepted(self, client, wav):
         """language= form field is accepted without error."""
         r = client.post(
-            "/v1/audio/transcriptions",
+            "/whisper-cpp/v1/audio/transcriptions",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"language": "fr"},
         )
@@ -198,7 +198,7 @@ class TestOpenAITranscriptionsEndpoint:
     def test_response_format_text(self, client, wav):
         """response_format=text returns plain text."""
         r = client.post(
-            "/v1/audio/transcriptions",
+            "/whisper-cpp/v1/audio/transcriptions",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"response_format": "text"},
         )
@@ -208,7 +208,7 @@ class TestOpenAITranscriptionsEndpoint:
     def test_empty_transcript(self, empty_client, wav):
         """Empty model transcript returns empty text field."""
         r = empty_client.post(
-            "/v1/audio/transcriptions",
+            "/whisper-cpp/v1/audio/transcriptions",
             files={"file": ("audio.wav", wav, "audio/wav")},
         )
         assert r.status_code == 200
@@ -216,13 +216,13 @@ class TestOpenAITranscriptionsEndpoint:
 
     def test_missing_file_returns_422(self, client):
         """No file field → FastAPI validation error 422."""
-        r = client.post("/v1/audio/transcriptions", data={"model": "whisper-1"})
+        r = client.post("/whisper-cpp/v1/audio/transcriptions", data={"model": "whisper-1"})
         assert r.status_code == 422
 
     def test_temperature_and_prompt_accepted(self, client, wav):
         """temperature= and prompt= are accepted and silently ignored."""
         r = client.post(
-            "/v1/audio/transcriptions",
+            "/whisper-cpp/v1/audio/transcriptions",
             files={"file": ("audio.wav", wav, "audio/wav")},
             data={"temperature": "0.0", "prompt": "hint"},
         )


### PR DESCRIPTION
## Problem

Every vendor compat router is mounted under its own URL prefix (`/deepgram`, `/azure-stt`, `/wit`, …) — except two:

- **whisper.cpp** had **no prefix** (`APIRouter(tags=...)`), registering `/inference` and `/v1/audio/transcriptions` at the application root;
- **OpenAI Whisper** used the bare, generic **`/v1`** prefix.

Both therefore claimed `POST /v1/audio/transcriptions`. Because whisper.cpp is `include_router`-ed *after* OpenAI in `create_app()`, the whisper.cpp handler **shadowed** the OpenAI one — OpenAI SDK clients hitting `/v1/audio/transcriptions` silently got whisper.cpp's `{"text": ...}` instead of the OpenAI response schema.

## Fix

Give each router its own dedicated vendor prefix, like the rest (and matching the prefixes the docs already described):

| Router | Before | After |
|--------|--------|-------|
| OpenAI Whisper | `/v1/audio/transcriptions`, `/v1/audio/translations` | `/openai/v1/audio/transcriptions`, `/openai/v1/audio/translations` |
| whisper.cpp | `/inference`, `/v1/audio/transcriptions` (root) | `/whisper-cpp/inference`, `/whisper-cpp/v1/audio/transcriptions` |

The root `/v1` namespace is no longer claimed by any router. OpenAI SDK clients now point at `base_url=".../openai/v1"`, exactly as the example/docs already showed.

## Verification

- Updated whisper.cpp + OpenAI unit/integration tests to the new paths.
- `pytest test/unittests/` → **309 passed, 1 skipped**.
- Mounted both routers in one app (same order as `create_app()`) and confirmed via `TestClient`:
  - `POST /openai/v1/audio/transcriptions` → OpenAI router (requires `model`, OpenAI schema)
  - `POST /whisper-cpp/inference` + `POST /whisper-cpp/v1/audio/transcriptions` → whisper.cpp router
  - `POST /v1/audio/transcriptions` → **404** (root no longer claimed) — no shadowing.

Resolves the route-collision finding noted in #85. The docs PR (#85) will be updated to reference `/openai/v1/...` and `/whisper-cpp/...` accordingly.