### PR TITLE
feat(compat): add Groq-compatible STT endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ proxy's job.
 | Vendor | Prefix | Client (see `examples/`) |
 |--------|--------|--------------------------|
 | OpenAI Whisper | `/v1/audio/transcriptions` | official `openai` |
+| Groq | `/groq/openai/v1/audio/transcriptions` | official `groq` |
 | Deepgram | `/deepgram/v1/listen` | official `deepgram-sdk` |
 | Google Cloud STT | `/google/v1/speech:recognize` | HTTP |
 | AssemblyAI | `/assemblyai/v2/...` | official `assemblyai` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ is in [`../examples/`](../examples/); full reference in
 | Vendor | Prefix |
 | :--- | :--- |
 | OpenAI Whisper | `/v1/audio/{transcriptions,translations}` |
+| Groq | `/groq/openai/v1/audio/transcriptions` |
 | Deepgram | `/deepgram/v1/listen` (HTTP + WS) |
 | Google Cloud STT | `/google/v1/speech:recognize` |
 | AssemblyAI | `/assemblyai/v2/{upload,transcript,realtime/ws}` |

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -28,6 +28,7 @@ client script for each is in [`../examples/`](../examples/).
 | Vendor | Method | Path | Client / example |
 | :--- | :--- | :--- | :--- |
 | OpenAI Whisper | POST | `/v1/audio/transcriptions`, `/v1/audio/translations` | official `openai` — [`openai_whisper_example.py`](../examples/openai_whisper_example.py) |
+| Groq | POST | `/groq/openai/v1/audio/transcriptions` | official `groq` — [`groq_example.py`](../examples/groq_example.py) — OpenAI-compatible, returns an extra `x_groq` block |
 | Deepgram | POST / WS | `/deepgram/v1/listen` | official `deepgram-sdk` — [`deepgram_example.py`](../examples/deepgram_example.py) |
 | Google Cloud STT | POST | `/google/v1/speech:recognize` | HTTP — [`../examples/`](../examples/) |
 | AssemblyAI | POST / GET / WS | `/assemblyai/v2/upload`, `/assemblyai/v2/transcript`, realtime WS | official `assemblyai` — [`assemblyai_example.py`](../examples/assemblyai_example.py) |

--- a/examples/groq_example.py
+++ b/examples/groq_example.py
@@ -1,0 +1,36 @@
+"""Drive the official Groq SDK against an ovos-stt-http-server instance.
+
+Groq exposes Whisper through an OpenAI-compatible surface rooted at
+``/openai/v1``; the ovos-stt-http-server Groq router mounts the same shape
+under ``/groq``.
+
+Prerequisites:
+    pip install groq
+    ovos-stt-server --engine <some-ovos-stt-plugin> --port 8080
+
+Usage:
+    python examples/groq_example.py path/to/clip.wav
+"""
+import sys
+from pathlib import Path
+
+from groq import Groq
+
+
+OVOS_HOST = "http://localhost:8080"
+
+
+def main(audio_path: str) -> None:
+    client = Groq(api_key="ignored", base_url=f"{OVOS_HOST}/groq")
+    with open(audio_path, "rb") as f:
+        result = client.audio.transcriptions.create(
+            file=(Path(audio_path).name, f.read()),
+            model="whisper-large-v3",
+        )
+    print(result.text)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <audio.wav>")
+    main(sys.argv[1])

--- a/ovos_stt_http_server/__init__.py
+++ b/ovos_stt_http_server/__init__.py
@@ -225,6 +225,8 @@ def create_app(stt_plugin: str, lang_plugin: str = None, multi: bool = False):
     app.include_router(make_vosk_server_router(model))
     from ovos_stt_http_server.routers.kaldi_gstreamer import make_kaldi_gstreamer_router
     app.include_router(make_kaldi_gstreamer_router(model))
+    from ovos_stt_http_server.routers.groq import make_groq_router
+    app.include_router(make_groq_router(model))
 
     # Mount MCP server when the optional dependency is available.
     try:

--- a/ovos_stt_http_server/routers/groq.py
+++ b/ovos_stt_http_server/routers/groq.py
@@ -1,0 +1,104 @@
+# Licensed under the Apache License, Version 2.0
+"""Groq-compatible STT endpoint.
+
+Groq serves Whisper through an OpenAI-compatible surface rooted at
+``/openai/v1``.  Existing Groq clients (the official ``groq`` SDK, or the
+``openai`` SDK pointed at ``https://api.groq.com/openai/v1``) send
+``multipart/form-data`` to ``POST /openai/v1/audio/transcriptions`` exactly as
+the OpenAI Whisper API does; the JSON response carries an extra ``x_groq``
+metadata block.
+
+Usage::
+
+    from ovos_stt_http_server.routers.groq import make_groq_router
+    app.include_router(make_groq_router(model))
+
+Then point the SDK at the server::
+
+    from groq import Groq
+    client = Groq(api_key="ignored", base_url="http://localhost:8080")
+    result = client.audio.transcriptions.create(file=audio, model="whisper-large-v3")
+"""
+import io
+import time
+import uuid
+import wave
+from typing import Optional
+
+from fastapi import APIRouter, File, Form, HTTPException, Header, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+from ovos_plugin_manager.utils.audio import AudioData
+
+
+def _audio_data_from_upload(file_bytes: bytes, sample_rate: int = 16000, sample_width: int = 2) -> AudioData:
+    """Wrap uploaded bytes in AudioData, reading WAV metadata when present."""
+    try:
+        with wave.open(io.BytesIO(file_bytes), "r") as wf:
+            sample_rate = wf.getframerate()
+            sample_width = wf.getsampwidth()
+            file_bytes = wf.readframes(wf.getnframes())
+    except Exception:
+        pass  # not a WAV — use raw bytes with defaults
+    return AudioData(file_bytes, sample_rate, sample_width)
+
+
+def make_groq_router(model) -> APIRouter:
+    """Create a Groq-compatible router and attach it to *model*.
+
+    Exposes ``POST /groq/openai/v1/audio/transcriptions`` accepting the same
+    ``multipart/form-data`` payload as the OpenAI Whisper API. The ``model`` and
+    auth fields are accepted for client compatibility but not forwarded to the
+    OVOS engine.
+
+    Args:
+        model: Any object with ``process_audio(audio: AudioData, lang: str)``
+            returning a transcription string.
+
+    Returns:
+        Configured :class:`~fastapi.APIRouter` prefixed with ``/groq``.
+    """
+    router = APIRouter(prefix="/groq", tags=["groq"])
+
+    @router.post(
+        "/openai/v1/audio/transcriptions",
+        summary="Transcribe audio (Groq Whisper-compatible)",
+    )
+    async def transcriptions(
+        file: UploadFile = File(..., description="Audio file to transcribe."),
+        model_name: str = Form(..., alias="model", description="Model name (accepted, ignored)."),
+        language: Optional[str] = Form(default=None, description="ISO-639-1 language code."),
+        prompt: Optional[str] = Form(default=None, description="Prompt hint (accepted, ignored)."),
+        response_format: Optional[str] = Form(default="json", description="json, text or verbose_json."),
+        temperature: Optional[float] = Form(default=0.0, description="Sampling temperature (ignored)."),
+        authorization: Optional[str] = Header(default=None, description="Bearer token (accepted, ignored)."),
+    ):
+        """Transcribe audio using the OVOS STT plugin, Groq response shape.
+
+        Returns ``{"text": ..., "x_groq": {...}}`` for ``json``/``verbose_json``
+        (the extra ``x_groq`` block is what distinguishes Groq from plain
+        OpenAI), or plain text for ``text``.
+        """
+        file_bytes = await file.read()
+        if not file_bytes:
+            raise HTTPException(status_code=400, detail="Empty audio file.")
+
+        audio = _audio_data_from_upload(file_bytes)
+        lang = language or "auto"
+        transcript = model.process_audio(audio, lang) or ""
+
+        fmt = (response_format or "json").lower()
+        if fmt == "text":
+            return PlainTextResponse(content=transcript)
+        if fmt in ("json", "verbose_json"):
+            return JSONResponse(content={
+                "text": transcript,
+                "x_groq": {"id": f"req_{uuid.uuid4().hex[:24]}"},
+            })
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported response_format: {response_format!r}. "
+                   f"Use one of: json, text, verbose_json.",
+        )
+
+    return router

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ test = [
     "pydub",
     # vendor client SDKs driven by the e2e tests
     "openai", "deepgram-sdk", "assemblyai", "boto3", "google-cloud-speech",
-    "ibm-watson", "speechmatics-batch", "speechmatics-rt", "wit",
+    "ibm-watson", "speechmatics-batch", "speechmatics-rt", "wit", "groq",
     # self-hosted / streaming protocol clients
     "grpcio", "protobuf", "grpcio-tools", "paho-mqtt", "amqtt",
     # MCP server, exercised by the MCP/UTCP tests

--- a/test/integration/test_groq_sdk_live.py
+++ b/test/integration/test_groq_sdk_live.py
@@ -1,0 +1,33 @@
+"""Live test: drive the official Groq SDK against our /groq router.
+
+Groq's client defaults to ``https://api.groq.com`` and appends
+``/openai/v1/audio/transcriptions``; pointing ``base_url`` at ``{server}/groq``
+makes it hit our router unchanged.
+"""
+import pytest
+
+from test.integration.conftest import make_silent_wav, run_live_server
+
+
+@pytest.fixture(scope="module")
+def base_url():
+    from ovos_stt_http_server.routers.groq import make_groq_router
+
+    def register(app, model):
+        app.include_router(make_groq_router(model))
+
+    yield from run_live_server(register)
+
+
+def test_transcribe_via_groq_sdk(base_url, tmp_path):
+    import groq
+
+    client = groq.Groq(api_key="ignored", base_url=f"{base_url}/groq")
+
+    wav = tmp_path / "clip.wav"
+    wav.write_bytes(make_silent_wav())
+    with open(wav, "rb") as f:
+        result = client.audio.transcriptions.create(
+            file=(wav.name, f.read()), model="whisper-large-v3"
+        )
+    assert result.text == "hello world"

--- a/test/unittests/test_groq.py
+++ b/test/unittests/test_groq.py
@@ -1,0 +1,83 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the Groq-compatible router (no live server, no API key)."""
+import io
+import wave
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _wav_bytes(frames: int = 160) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * frames)
+    return buf.getvalue()
+
+
+class FakeModel:
+    def process_audio(self, audio, lang: str = "auto") -> str:
+        return "hello world"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    from ovos_stt_http_server.routers.groq import make_groq_router
+    app = FastAPI()
+    app.include_router(make_groq_router(FakeModel()))
+    return TestClient(app)
+
+
+PATH = "/groq/openai/v1/audio/transcriptions"
+
+
+class TestGroqRouter:
+    def test_json_default(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["text"] == "hello world"
+        # the x_groq block is what distinguishes Groq from plain OpenAI
+        assert "x_groq" in body and body["x_groq"]["id"].startswith("req_")
+
+    def test_text_format(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3", "response_format": "text"})
+        assert r.status_code == 200
+        assert r.text == "hello world"
+
+    def test_language_param(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3", "language": "pt"})
+        assert r.status_code == 200
+        assert r.json()["text"] == "hello world"
+
+    def test_bearer_header_accepted(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3"},
+                        headers={"Authorization": "Bearer gsk_fake"})
+        assert r.status_code == 200
+
+    def test_empty_file_400(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", b"", "audio/wav")},
+                        data={"model": "whisper-large-v3"})
+        assert r.status_code == 400
+
+    def test_missing_model_422(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")}, data={})
+        assert r.status_code == 422
+
+    def test_unknown_format_422(self, client):
+        r = client.post(PATH, files={"file": ("a.wav", _wav_bytes(), "audio/wav")},
+                        data={"model": "whisper-large-v3", "response_format": "xml"})
+        assert r.status_code == 422
+
+    def test_raw_bytes_fallback(self, client):
+        r = client.post(PATH, files={"file": ("a.raw", b"\x00\x00" * 160, "application/octet-stream")},
+                        data={"model": "whisper-large-v3"})
+        assert r.status_code == 200
+        assert r.json()["text"] == "hello world"


### PR DESCRIPTION
Split of #83 — 1 of 3 (Groq). Gladia and ElevenLabs Scribe ship as separate PRs.

Rebased onto current `dev` so it adds only the Groq backend (the original #83 branch predates the docs/test-infra work in #85–#87 and would have reverted it).

## Summary
- Mounts a `/groq` router: `POST /groq/openai/v1/audio/transcriptions` — Groq's OpenAI-compatible Whisper surface (multipart/form-data, plus the extra `x_groq` block that distinguishes it from plain OpenAI). Registered in `create_app()`.
- `examples/groq_example.py` drives the official `groq` SDK pointed at `/groq`.
- README + `docs/` vendor tables get a Groq row.

## Tests (no importorskip — SDK required for CI)
- Unit tests via FastAPI `TestClient`.
- `test/integration/test_groq_sdk_live.py` boots the router and drives the **official `groq` SDK** end-to-end; `groq` is added to the required `test` extra so it runs in CI rather than being skipped.

## Verification
- `pytest test/unittests/test_groq.py test/integration/test_groq_sdk_live.py` → **9 passed** locally.