### PR TITLE
feat: audio and utterance transformer pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ See [`examples/native_example.py`](examples/native_example.py) for a runnable
 script that reads a WAV file and posts its PCM frames. Full reference:
 [docs/index.md](docs/index.md).
 
+### Transformer pipelines
+
+The server can run OVOS transformer plugins around transcription, on every
+endpoint: **audio transformers** process audio before STT (an
+`AudioLanguageDetector` in the chain resolves `lang=auto`) and **utterance
+transformers** rewrite the transcript before it is returned. Opt-in via the
+standard mycroft.conf sections:
+
+```json
+{
+  "utterance_transformers": {
+    "ovos-utterance-corrections-plugin": {}
+  }
+}
+```
+
+Enabling an utterance transformer server-side means clients receive a
+**different transcript than the raw STT output** — that's the tool for
+fleet-wide vocabulary corrections. See
+[docs/transformers.md](docs/transformers.md) for when to run transformers
+server-side vs on-device and how to avoid double-processing.
+
 ## AI Agent Integration
 
 ### MCP — Model Context Protocol
@@ -273,6 +295,7 @@ Each plugin can ship its own Dockerfile in its repository using
 | [docs/index.md](docs/index.md) | Overview, native HTTP API, architecture, audio format |
 | [docs/api-compatibility.md](docs/api-compatibility.md) | Vendor routers — prefixes, endpoints, clients |
 | [docs/audio-formats.md](docs/audio-formats.md) | Accepted audio encodings and conversion |
+| [docs/transformers.md](docs/transformers.md) | Audio/utterance transformer plugins around transcription |
 | [docs/wyoming-integration.md](docs/wyoming-integration.md) | Home Assistant Voice / Wyoming bridge |
 | [docs/voice-pihole.md](docs/voice-pihole.md) | DNS-redirect + reverse-proxy recipes per vendor |
 

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -1,0 +1,55 @@
+# Transformer Pipelines
+
+The server can run OVOS transformer plugins around transcription. Both
+hooks live in the model containers, so **every** surface gets them: the
+native `/stt` endpoint, all vendor-compat routers, the websocket streaming
+routes, MCP and UTCP.
+
+- **Audio transformers** process the audio *before* the STT stage. When the
+  chain includes an `AudioLanguageDetector`, its detected language resolves
+  `lang=auto` (an explicitly requested language always wins).
+- **Utterance transformers** rewrite the *transcript* before it is
+  returned.
+
+## Configuration
+
+Loading is config-gated and opt-in via the standard mycroft.conf sections;
+with no config the server behaves exactly as before:
+
+```json
+{
+  "audio_transformers": {
+    "ovos-audio-transformer-plugin-speechbrain-langdetect": {}
+  },
+  "utterance_transformers": {
+    "ovos-utterance-corrections-plugin": {}
+  }
+}
+```
+
+Chains run in ascending priority order (OVOS-TRANSFORM §4); an explicit
+`"order"` list in a section wins over priorities. In multi-model mode
+(`--multi`) one set of transformer instances is shared across the
+per-language engines. See the
+[ovos-plugin-manager transformer docs](https://github.com/OpenVoiceOS/ovos-plugin-manager/blob/dev/docs/transformers.md)
+for the full contract.
+
+## When to use — and the surprise factor
+
+An utterance transformer on the *server* means clients receive a
+**different transcript than what the STT engine heard** — a client sends
+audio saying "who is the speaker of teh house" and gets back a corrected
+string it can't distinguish from raw STT output. Do it on purpose:
+
+- **Fleet-wide corrections**: domain vocabulary fixes (product names,
+  callsigns, jargon) applied once, for every client of this server.
+- **Language routing**: an `AudioLanguageDetector` in the audio chain lets
+  heterogeneous clients send `lang=auto` and still hit the right model.
+- **Audio cleanup**: server-side denoise before STT when clients are thin
+  and can't do it themselves.
+
+If the effect should be **per-device** (one bad microphone needs denoise),
+run the audio transformer on that device instead — and never enable the
+same plugin on both sides, or it is applied twice. Similarly, if the OVOS
+stack consuming this server already runs utterance transformers
+(ovos-core does), enable each text plugin in exactly one of the two places.

--- a/ovos_stt_http_server/__init__.py
+++ b/ovos_stt_http_server/__init__.py
@@ -17,6 +17,8 @@ from fastapi.responses import PlainTextResponse
 from ovos_config import Configuration
 from ovos_plugin_manager.audio_transformers import load_audio_transformer_plugin, AudioLanguageDetector
 from ovos_plugin_manager.stt import load_stt_plugin
+from ovos_plugin_manager.transformer_services import (AudioTransformersService,
+                                                      UtteranceTransformersService)
 from ovos_plugin_manager.utils.audio import AudioFile, AudioData
 from ovos_utils.log import LOG
 from starlette.requests import Request
@@ -39,8 +41,45 @@ def _load_translator():
         return None
 
 
-class ModelContainer:
+class TransformerPipelines:
+    """Transformer pipelines shared by the model containers.
+
+    Loading is config-gated and opt-in via the mycroft.conf
+    ``audio_transformers`` / ``utterance_transformers`` sections; with no
+    config both chains are empty and audio/transcripts pass through
+    untouched.
+    """
+
+    def init_transformers(self):
+        self.audio_transformers = AudioTransformersService(
+            config=Configuration().get("audio_transformers") or {})
+        self.utterance_transformers = UtteranceTransformersService(
+            config=Configuration().get("utterance_transformers") or {})
+
+    def transform_audio(self, audio: AudioData) -> Tuple[AudioData, dict]:
+        """Run the audio transformer chain before the STT stage.
+
+        Returns the (possibly modified) audio and the chain's context —
+        e.g. ``stt_lang`` when an AudioLanguageDetector is in the chain.
+        """
+        if not self.audio_transformers.plugins:
+            return audio, {}
+        chunk, context = self.audio_transformers.transform(audio.frame_data)
+        audio = AudioData(chunk, audio.sample_rate, audio.sample_width)
+        return audio, context
+
+    def transform_utterance(self, utterance: str, lang: str) -> str:
+        """Run the utterance transformer chain on a transcript."""
+        if not utterance or not self.utterance_transformers.plugins:
+            return utterance
+        utterances, _ = self.utterance_transformers.transform(
+            [utterance], {"lang": lang})
+        return utterances[0] if utterances else utterance
+
+
+class ModelContainer(TransformerPipelines):
     def __init__(self, plugin: str, lang_plugin: str = None, config: dict = None):
+        self.init_transformers()
         plugin = load_stt_plugin(plugin)
         self.lang_plugin = None
         if not plugin:
@@ -63,13 +102,19 @@ class ModelContainer:
         return self.lang_plugin.detect(audio, valid_langs)
 
     def process_audio(self, audio: AudioData, lang: str = "auto"):
-        return self.engine.execute(audio, language=lang) or ""
+        audio, context = self.transform_audio(audio)
+        if lang == "auto" and context.get("stt_lang"):
+            lang = context["stt_lang"]
+        utterance = self.engine.execute(audio, language=lang) or ""
+        return self.transform_utterance(utterance, lang)
 
 
-class MultiModelContainer:
+class MultiModelContainer(TransformerPipelines):
     """ loads 1 model per language """
 
     def __init__(self, plugin: str, lang_plugin: str = None, config: dict = None):
+        # transformer chains are shared across the per-language engines
+        self.init_transformers()
         self.plugin_class = load_stt_plugin(plugin)
         self.lang_plugin = None
         if not self.plugin_class:
@@ -114,8 +159,12 @@ class MultiModelContainer:
         Returns:
             str: Transcribed text for the audio, or an empty string if no transcription is produced.
         """
+        audio, context = self.transform_audio(audio)
+        if lang == "auto" and context.get("stt_lang"):
+            lang = context["stt_lang"]
         engine = self.get_engine(lang)
-        return engine.execute(audio, language=lang) or ""
+        utterance = engine.execute(audio, language=lang) or ""
+        return self.transform_utterance(utterance, lang)
 
 
 def create_app(stt_plugin: str, lang_plugin: str = None, multi: bool = False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 dependencies = [
-    "ovos-plugin-manager>=2.1.1,<3.0.0",
+    "ovos-plugin-manager>=2.10.0a1,<3.0.0",
     "fastapi~=0.95",
     "uvicorn~=0.22",
     "ovos-utils>=0.0.32,<1.0.0",

--- a/test/unittests/conftest.py
+++ b/test/unittests/conftest.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def empty_transformer_config():
+    """Keep tests hermetic: never pick up transformer sections from the
+    machine-local mycroft.conf when containers initialize their pipelines."""
+    with patch("ovos_stt_http_server.Configuration", return_value={}):
+        yield

--- a/test/unittests/test_server.py
+++ b/test/unittests/test_server.py
@@ -216,3 +216,83 @@ def test_start_stt_server_returns_app(load_stt):
     app, model = srv.start_stt_server("fake-stt")
     assert app is not None
     assert model is not None
+
+
+# ---------- Transformer pipelines ----------
+
+class FakeUtteranceService:
+    plugins = ["fake"]
+
+    def transform(self, utterances, context=None):
+        return [f"corrected:{u}" for u in utterances], {"touched": True}
+
+
+class FakeAudioService:
+    plugins = ["fake"]
+
+    def transform(self, chunk, context=None):
+        return chunk[::-1], {"stt_lang": "de"}
+
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_transformers_off_by_default(load_stt):
+    """With no transformer config the transcript passes through untouched."""
+    load_stt.return_value = FakeSTT
+    mc = srv.ModelContainer("fake")
+    assert mc.audio_transformers.plugins == []
+    assert mc.utterance_transformers.plugins == []
+    assert mc.process_audio(b"x", "en") == "transcribed:en"
+
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_utterance_transformers_rewrite_transcript(load_stt):
+    load_stt.return_value = FakeSTT
+    mc = srv.ModelContainer("fake")
+    mc.utterance_transformers = FakeUtteranceService()
+    assert mc.process_audio(b"x", "en") == "corrected:transcribed:en"
+
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_audio_transformers_run_before_stt_and_set_lang(load_stt):
+    seen = {}
+
+    class RecordingSTT(FakeSTT):
+        def execute(self, audio, language=None):
+            seen["audio"] = audio
+            seen["language"] = language
+            return "ok"
+
+    load_stt.return_value = RecordingSTT
+    mc = srv.ModelContainer("fake")
+    mc.audio_transformers = FakeAudioService()
+    audio = srv.AudioData(b"abc", 16000, 2)
+    out = mc.process_audio(audio, "auto")
+    assert out == "ok"
+    # chain modified the audio and its stt_lang resolved the "auto" lang
+    assert seen["audio"].frame_data == b"cba"
+    assert seen["language"] == "de"
+
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_explicit_lang_wins_over_detected(load_stt):
+    seen = {}
+
+    class RecordingSTT(FakeSTT):
+        def execute(self, audio, language=None):
+            seen["language"] = language
+            return "ok"
+
+    load_stt.return_value = RecordingSTT
+    mc = srv.ModelContainer("fake")
+    mc.audio_transformers = FakeAudioService()
+    mc.process_audio(srv.AudioData(b"abc", 16000, 2), "pt")
+    assert seen["language"] == "pt"
+
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_multi_model_container_shares_transformers(load_stt):
+    load_stt.return_value = FakeSTT
+    mm = srv.MultiModelContainer("fake")
+    mm.utterance_transformers = FakeUtteranceService()
+    assert mm.process_audio(b"x", "en") == "corrected:transcribed:en"
+    assert mm.process_audio(b"x", "de") == "corrected:transcribed:de"


### PR DESCRIPTION
## What

Adds OVOS transformer pipeline support to the STT server, using the canonical runner services from OpenVoiceOS/ovos-plugin-manager#410:

- **Audio transformers** process audio before the STT stage. When the chain includes an `AudioLanguageDetector`, its `stt_lang` resolves `lang=auto` (an explicitly requested language always wins).
- **Utterance transformers** rewrite the transcript before it is returned.

Both hooks live in `ModelContainer.process_audio()` / `MultiModelContainer.process_audio()` — the choke-point every native endpoint, vendor-compat router, websocket streaming route, MCP and UTCP surface flows through.

## Behavior

- Config-gated and opt-in via the standard `audio_transformers` / `utterance_transformers` mycroft.conf sections; with no config the server behaves exactly as before.
- Chains follow OVOS-TRANSFORM §4 (ascending priority, explicit `"order"` list supported).
- `MultiModelContainer` shares one set of transformer instances across its lazily-created per-language engines.

## Testing

New unit tests cover default-off behavior, transcript rewriting, pre-STT audio transformation with `stt_lang` resolution of `lang=auto`, explicit-lang precedence, and instance sharing in the multi container. An autouse fixture keeps the suite hermetic against machine-local transformer config.

Example config:
```json
{
  "utterance_transformers": {
    "ovos-utterance-corrections-plugin": {}
  }
}
```

## Depends on

- OpenVoiceOS/ovos-plugin-manager#410 — this PR pins `ovos-plugin-manager>=2.10.0a1`. CI stays red until that alpha is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)