### PR TITLE
refactor: migrate MCP server to the fastmcp package

### DIFF
--- a/ovos_stt_http_server/mcp_server.py
+++ b/ovos_stt_http_server/mcp_server.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 _MCP_AVAILABLE = False
 try:
-    from mcp.server.fastmcp import FastMCP  # type: ignore
+    from fastmcp import FastMCP  # type: ignore
     _MCP_AVAILABLE = True
 except ImportError:
     pass
@@ -70,7 +70,7 @@ def build_mcp_server(
         A ready-to-use FastMCP server.
     """
     _require_mcp()
-    from mcp.server.fastmcp import FastMCP  # type: ignore
+    from fastmcp import FastMCP  # type: ignore
     from ovos_plugin_manager.utils.audio import AudioData
 
     mcp = FastMCP(server_name)
@@ -153,18 +153,20 @@ def mount_mcp_on_fastapi(app, model, path: str = "/mcp") -> None:
     # Serve the streamable-HTTP transport at the mount root so the endpoint
     # is exactly *path* (FastMCP defaults to an internal /mcp sub-path, which
     # would yield /mcp/mcp when mounted).
-    mcp.settings.streamable_http_path = "/"
-    app.mount(path, mcp.streamable_http_app())
+    mcp_app = mcp.http_app(path="/", transport="streamable-http")
+    app.mount(path, mcp_app)
 
     # Starlette does not propagate lifespan events to mounted sub-apps, and
-    # the streamable transport requires its session manager running.
+    # the streamable-HTTP transport requires its session manager running.
+    # FastMCP exposes the required lifespan via `mcp_app.lifespan`; it must
+    # be entered alongside the host application's own lifespan.
     from contextlib import asynccontextmanager
     _original_lifespan = app.router.lifespan_context
 
     @asynccontextmanager
     async def _lifespan_with_mcp(host_app):
         async with _original_lifespan(host_app):
-            async with mcp.session_manager.run():
+            async with mcp_app.lifespan(host_app):
                 yield
 
     app.router.lifespan_context = _lifespan_with_mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,14 @@ test = [
     # self-hosted / streaming protocol clients
     "grpcio", "protobuf", "grpcio-tools", "paho-mqtt", "amqtt",
     # MCP server, exercised by the MCP/UTCP tests
-    "mcp>=1.0.0,<2.0.0",
+    "fastmcp>=3,<4",
 ]
 # vosk-webrtc needs aiortc, which builds against system ffmpeg-7 dev headers and
 # has no wheels for the newest Python in the CI matrix. It is therefore kept out
 # of the required `test` extra; its e2e test skips when aiortc is absent (the
 # webrtc router is itself an optional, ImportError-gated feature of the server).
 test-webrtc = ["aiortc"]
-mcp = ["mcp>=1.0.0,<2.0.0"]
+mcp = ["fastmcp>=3,<4"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-stt-http-server"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,13 @@ test = [
     # SpeechRecognition-backed chromium SDK e2e test
     "SpeechRecognition", "ovos-stt-plugin-chromium",
     # self-hosted / streaming protocol clients
-    "grpcio", "protobuf", "grpcio-tools", "paho-mqtt", "amqtt",
+    # amqtt is pinned to the 0.11.x line (not just left unconstrained) because
+    # the unconstrained top-level "websockets" dep above can otherwise resolve
+    # to a version that conflicts with amqtt 0.11.x's exact websockets==15.0.1
+    # pin; without this floor the resolver silently backtracks amqtt all the
+    # way down to the ancient, broken 0.10.0a1 prerelease on some interpreters
+    # (observed on Python 3.10), which does not even provide the amqtt module.
+    "grpcio", "protobuf", "grpcio-tools", "paho-mqtt", "amqtt>=0.11,<1",
     # MCP server, exercised by the MCP/UTCP tests
     "fastmcp>=3,<4",
 ]

--- a/test/end2end/test_e2e_mcp_utcp.py
+++ b/test/end2end/test_e2e_mcp_utcp.py
@@ -110,7 +110,7 @@ def mcp_server():
         pytest.skip("mcp extra not installed")
 
     mcp = build_mcp_server(stub)
-    mcp_app = mcp.streamable_http_app()
+    mcp_app = mcp.http_app()
 
     try:
         base_url, server, thread = _start_server(mcp_app, health_path="/mcp")

--- a/test/unittests/test_mcp.py
+++ b/test/unittests/test_mcp.py
@@ -12,7 +12,7 @@
 """Tests for the MCP server integration.
 
 All tests mock the STT engine so no real model is required.
-The ``mcp`` package itself is required (pip install 'ovos-stt-http-server[mcp]').
+The ``fastmcp`` package itself is required (pip install 'ovos-stt-http-server[mcp]').
 """
 import asyncio
 import base64
@@ -38,8 +38,8 @@ def _get_tools(mcp):
 
 
 def _call_tool(mcp, name, kwargs):
-    content_list, _structured = asyncio.run(mcp.call_tool(name, kwargs))
-    return content_list
+    result = asyncio.run(mcp.call_tool(name, kwargs))
+    return result.content
 
 
 def _extract_text(content_list) -> str:
@@ -62,10 +62,10 @@ def _extract_text(content_list) -> str:
 class TestBuildMcpServer:
     @pytest.fixture(autouse=True)
     def _check_mcp(self):
-        import mcp
+        import fastmcp
 
     def test_returns_fastmcp_instance(self):
-        from mcp.server.fastmcp import FastMCP
+        from fastmcp import FastMCP
         from ovos_stt_http_server.mcp_server import build_mcp_server
         mcp = build_mcp_server(_make_model())
         assert isinstance(mcp, FastMCP)
@@ -86,7 +86,7 @@ class TestBuildMcpServer:
         from ovos_stt_http_server.mcp_server import build_mcp_server
         mcp = build_mcp_server(_make_model())
         transcribe = next(t for t in _get_tools(mcp) if t.name == "transcribe")
-        props = transcribe.inputSchema.get("properties", {})
+        props = transcribe.parameters.get("properties", {})
         # at least one of the two audio input fields must be present
         assert "audio_b64" in props or "audio_path" in props
 
@@ -94,11 +94,11 @@ class TestBuildMcpServer:
         from ovos_stt_http_server.mcp_server import build_mcp_server
         mcp = build_mcp_server(_make_model())
         transcribe = next(t for t in _get_tools(mcp) if t.name == "transcribe")
-        props = transcribe.inputSchema.get("properties", {})
+        props = transcribe.parameters.get("properties", {})
         assert "lang" in props
 
     def test_custom_server_name_accepted(self):
-        from mcp.server.fastmcp import FastMCP
+        from fastmcp import FastMCP
         from ovos_stt_http_server.mcp_server import build_mcp_server
         mcp = build_mcp_server(_make_model(), server_name="my-stt")
         assert isinstance(mcp, FastMCP)
@@ -111,13 +111,13 @@ class TestBuildMcpServer:
 class TestTranscribeTool:
     @pytest.fixture(autouse=True)
     def _check_mcp(self):
-        import mcp
+        import fastmcp
 
     def _call(self, model, **kwargs):
         from ovos_stt_http_server.mcp_server import build_mcp_server
         mcp = build_mcp_server(model)
-        content_list, _ = asyncio.run(mcp.call_tool("transcribe", kwargs))
-        return _extract_text(content_list)
+        result = asyncio.run(mcp.call_tool("transcribe", kwargs))
+        return _extract_text(result.content)
 
     def test_transcribe_with_audio_b64(self):
         model = _make_model("hello world")
@@ -246,7 +246,7 @@ class TestTranscribeTool:
 class TestMountMcpOnFastapi:
     @pytest.fixture(autouse=True)
     def _check_mcp(self):
-        import mcp
+        import fastmcp
 
     def test_mount_does_not_raise(self):
         from fastapi import FastAPI
@@ -295,15 +295,12 @@ class TestMcpModuleImportDegradation:
         import sys
         import importlib
 
-        # Block the mcp package by inserting a sentinel that raises ImportError.
-        sentinel = object()  # not a real module
-        blocked_keys = [k for k in list(sys.modules) if k == "mcp" or k.startswith("mcp.")]
+        # Block the fastmcp package by inserting a sentinel that raises ImportError.
+        blocked_keys = [k for k in list(sys.modules) if k == "fastmcp" or k.startswith("fastmcp.")]
         saved = {k: sys.modules.pop(k) for k in blocked_keys}
         # Use a fake module that raises on attribute access is complex;
-        # simpler: set the key to None which causes ImportError on `import mcp`.
-        sys.modules["mcp"] = None  # type: ignore
-        sys.modules["mcp.server"] = None  # type: ignore
-        sys.modules["mcp.server.fastmcp"] = None  # type: ignore
+        # simpler: set the key to None which causes ImportError on `import fastmcp`.
+        sys.modules["fastmcp"] = None  # type: ignore
 
         # Remove the already-cached mcp_server module so it re-executes.
         mcp_server_saved = sys.modules.pop("ovos_stt_http_server.mcp_server", None)
@@ -312,8 +309,7 @@ class TestMcpModuleImportDegradation:
             assert fresh_mod._MCP_AVAILABLE is False
         finally:
             # Restore everything.
-            for k in ["mcp", "mcp.server", "mcp.server.fastmcp"]:
-                sys.modules.pop(k, None)
+            sys.modules.pop("fastmcp", None)
             sys.modules.update(saved)
             if mcp_server_saved is not None:
                 sys.modules["ovos_stt_http_server.mcp_server"] = mcp_server_saved


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

mcp 2.x removed its bundled mcp.server.fastmcp module. fastmcp (Apache-2.0) is the maintained continuation of that module as a standalone package, so ovos_stt_http_server/mcp_server.py and its tests now import FastMCP from fastmcp instead. The mcp extra keeps its old name for backward-compatible install instructions, but now resolves to fastmcp>=3,<4. Nothing a client sees changes — the /mcp route, the streamable-HTTP wire protocol, and the transcribe tool's name, arguments, and behavior are all the same as before.

mount_mcp_on_fastapi() now builds the ASGI sub-app with fastmcp 3.x's http_app() and wires its lifespan into the host FastAPI app, replacing the removed streamable_http_app()/session_manager pair. The tests needed two small updates to match fastmcp's new return shapes: call_tool() now returns a ToolResult object with a .content attribute instead of the old (content, structured) tuple, and Tool objects expose .parameters instead of .inputSchema. No new console entrypoint was added — the server still only exposes MCP over the existing FastAPI HTTP mount.

Verified with an in-process smoke test against the shared venv's fastmcp 3.4.5: building the server, listing tools (just transcribe), calling it and getting back real transcribed text, and mounting it on a real FastAPI app to confirm /mcp actually gets registered with the new http_app()+lifespan wiring. The stdio transport was also started directly and confirmed to block on stdin as expected.

test/unittests/test_mcp.py is 24 passed, and test/end2end/test_e2e_mcp_utcp.py is 9 passed, including a real MCP handshake (initialize, list_tools, call_tool) driven over HTTP against a live uvicorn instance. The full suite across both is 345 passed.
