### PR TITLE
feat: make MCP mounting opt-in via --mcp flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Optional extras:
 
 | Extra | Installs | Enables |
 |-------|----------|---------|
-| `mcp` | `pip install "ovos-stt-http-server[mcp]"` | embedded [MCP](#mcp--model-context-protocol) server at `/mcp` |
+| `mcp` | `pip install "ovos-stt-http-server[mcp]"` | embedded [MCP](#mcp--model-context-protocol) server at `/mcp` (requires `--mcp` flag) |
 | `audio` | `pip install "ovos-stt-http-server[audio]"` | non-WAV audio decoding (`pydub`) for the vendor-compat routers |
 
 ## Configuration
@@ -58,7 +58,7 @@ The STT plugin is configured exactly as it would be inside an assistant, under
 ```bash
 $ ovos-stt-server --help
 usage: ovos-stt-server [-h] --engine ENGINE [--lang-engine LANG_ENGINE]
-                       [--host HOST] [--port PORT] [--multi]
+                       [--host HOST] [--port PORT] [--multi] [--mcp]
 
 options:
   -h, --help                 show this help message and exit
@@ -67,6 +67,7 @@ options:
   --host HOST                host to bind (default: 0.0.0.0)
   --port PORT                TCP port (default: 8080)
   --multi                    load one plugin instance per language (more memory)
+  --mcp                      mount MCP server at /mcp (requires ovos-stt-http-server[mcp])
 ```
 
 For example, to serve [faster-whisper](https://github.com/OpenVoiceOS/ovos-stt-plugin-fasterwhisper)
@@ -136,15 +137,19 @@ server-side vs on-device and how to avoid double-processing.
 
 ### MCP: Model Context Protocol
 
-Install the optional extra to expose the server as an MCP tool provider:
+Install the optional extra and start the server with `--mcp` to expose it as an
+MCP tool provider:
 
 ```bash
 pip install "ovos-stt-http-server[mcp]"
+ovos-stt-server --engine ovos-stt-plugin-fasterwhisper --mcp
 ```
 
-When `mcp` is installed, the server automatically mounts an MCP endpoint at `/mcp`
-using the streamable-HTTP transport (compatible with both the legacy SSE path `/mcp/sse`
-and the newer `POST /mcp` format).
+Installing the `mcp` extra alone does **not** mount the endpoint — the flag is
+required. With `--mcp` set, the server mounts an MCP endpoint at `/mcp` using
+the streamable-HTTP transport (compatible with both the legacy SSE path
+`/mcp/sse` and the newer `POST /mcp` format). If `--mcp` is passed without the
+extra installed, the server logs a warning and starts without `/mcp`.
 
 #### Connecting an MCP client
 

--- a/ovos_stt_http_server/__init__.py
+++ b/ovos_stt_http_server/__init__.py
@@ -173,7 +173,8 @@ class MultiModelContainer(TransformerPipelines):
         return self.transform_utterance(utterance, lang)
 
 
-def create_app(stt_plugin: str, lang_plugin: str = None, multi: bool = False):
+def create_app(stt_plugin: str, lang_plugin: str = None, multi: bool = False,
+               enable_mcp: bool = False):
     """
     Create and configure a FastAPI app that exposes STT and language-detection endpoints.
 
@@ -189,6 +190,7 @@ def create_app(stt_plugin: str, lang_plugin: str = None, multi: bool = False):
         stt_plugin: Name or identifier of the STT plugin to load.
         lang_plugin: Name or identifier of an optional language-detection plugin.
         multi: If True, use a MultiModelContainer (one engine per language).
+        enable_mcp: If True, mount the MCP server at /mcp (requires the `mcp` extra).
 
     Returns:
         tuple: (app, model) where `app` is the configured FastAPI application and `model` is
@@ -287,20 +289,23 @@ def create_app(stt_plugin: str, lang_plugin: str = None, multi: bool = False):
     from ovos_stt_http_server.routers.groq import make_groq_router
     app.include_router(make_groq_router(model))
 
-    # Mount MCP server when the optional dependency is available.
-    try:
-        from ovos_stt_http_server.mcp_server import mount_mcp_on_fastapi
-        mount_mcp_on_fastapi(app, model)
-    except ImportError:
-        LOG.debug("MCP extra not installed; skipping MCP server. "
-                  "Enable with: pip install 'ovos-stt-http-server[mcp]'")
+    # Mount MCP server only when explicitly requested via --mcp.
+    if enable_mcp:
+        try:
+            from ovos_stt_http_server.mcp_server import mount_mcp_on_fastapi
+            mount_mcp_on_fastapi(app, model)
+        except ImportError:
+            LOG.warning("MCP was requested (--mcp) but the optional dependency "
+                        "is not installed; skipping MCP server. "
+                        "Enable with: pip install 'ovos-stt-http-server[mcp]'")
 
     return app, model
 
 
 def start_stt_server(engine: str,
                      lang_engine: str = None,
-                     multi: bool = False) -> tuple:
+                     multi: bool = False,
+                     enable_mcp: bool = False) -> tuple:
     """
     Initialize and return a configured FastAPI STT server and its model container.
 
@@ -308,9 +313,10 @@ def start_stt_server(engine: str,
         engine: STT plugin name to load.
         lang_engine: Optional language-detection plugin name.
         multi: If True, load one engine per language via MultiModelContainer.
+        enable_mcp: If True, mount the MCP server at /mcp (requires the `mcp` extra).
 
     Returns:
         tuple: (app, model) — the FastAPI application and the model container.
     """
-    app, engine = create_app(engine, lang_engine, multi)
+    app, engine = create_app(engine, lang_engine, multi, enable_mcp)
     return app, engine

--- a/ovos_stt_http_server/__main__.py
+++ b/ovos_stt_http_server/__main__.py
@@ -27,10 +27,12 @@ def main():
     parser.add_argument("--host", help="host", default="0.0.0.0")
     parser.add_argument("--multi", help="Load a plugin instance per language (force lang support)",
                         action="store_true")
+    parser.add_argument("--mcp", help="mount MCP server at /mcp (requires ovos-stt-http-server[mcp])",
+                        action="store_true")
     args = parser.parse_args()
 
     server, engine = start_stt_server(args.engine, lang_engine=args.lang_engine,
-                                      multi=bool(args.multi))
+                                      multi=bool(args.multi), enable_mcp=bool(args.mcp))
     LOG.info("Server Started")
     uvicorn.run(server, host=args.host, port=int(args.port))
 

--- a/test/unittests/test_main.py
+++ b/test/unittests/test_main.py
@@ -16,8 +16,8 @@ def test_main_runs(monkeypatch):
     from ovos_stt_http_server import __main__
     calls = {}
 
-    def fake_start(engine, lang_engine=None, multi=False):
-        calls["start"] = (engine, lang_engine, multi)
+    def fake_start(engine, lang_engine=None, multi=False, enable_mcp=False):
+        calls["start"] = (engine, lang_engine, multi, enable_mcp)
         return ("app-obj", "model-obj")
 
     def fake_run(server, host, port):
@@ -30,5 +30,27 @@ def test_main_runs(monkeypatch):
         ["ovos-stt-server", "--engine", "fake", "--port", "1234", "--multi"],
     )
     __main__.main()
-    assert calls["start"] == ("fake", None, True)
+    assert calls["start"] == ("fake", None, True, False)
     assert calls["run"] == ("app-obj", "0.0.0.0", 1234)
+
+
+def test_main_runs_with_mcp_flag(monkeypatch):
+    """--mcp on the CLI must thread enable_mcp=True through to start_stt_server."""
+    from ovos_stt_http_server import __main__
+    calls = {}
+
+    def fake_start(engine, lang_engine=None, multi=False, enable_mcp=False):
+        calls["start"] = (engine, lang_engine, multi, enable_mcp)
+        return ("app-obj", "model-obj")
+
+    def fake_run(server, host, port):
+        calls["run"] = (server, host, port)
+
+    monkeypatch.setattr(__main__, "start_stt_server", fake_start)
+    monkeypatch.setattr(__main__.uvicorn, "run", fake_run)
+    monkeypatch.setattr(
+        sys, "argv",
+        ["ovos-stt-server", "--engine", "fake", "--mcp"],
+    )
+    __main__.main()
+    assert calls["start"] == ("fake", None, False, True)

--- a/test/unittests/test_mcp.py
+++ b/test/unittests/test_mcp.py
@@ -328,13 +328,15 @@ class TestCreateAppMcpDegradation:
         with patch("ovos_stt_http_server.ModelContainer") as mc:
             mc.return_value = _make_model()
             from ovos_stt_http_server import create_app
-            app, model = create_app("mock-stt")
+            # enable_mcp=True so this exercises the mount attempt/degradation path;
+            # MCP is opt-in now, so create_app("mock-stt") alone would never try to mount.
+            app, model = create_app("mock-stt", enable_mcp=True)
 
         from fastapi import FastAPI
         assert isinstance(app, FastAPI)
 
     def test_create_app_mcp_import_error_caught(self):
-        """create_app() catches ImportError from mount_mcp_on_fastapi gracefully.
+        """create_app(enable_mcp=True) catches ImportError from mount_mcp_on_fastapi gracefully.
 
         Patches the mcp_server submodule in sys.modules so the ``from … import``
         inside create_app triggers an ImportError through the module's own guard.
@@ -350,7 +352,7 @@ class TestCreateAppMcpDegradation:
             sys.modules["ovos_stt_http_server.mcp_server"] = mcp_mod  # already patched
             try:
                 from ovos_stt_http_server import create_app
-                app, model = create_app("mock-stt")
+                app, model = create_app("mock-stt", enable_mcp=True)
             finally:
                 if saved is not None:
                     sys.modules["ovos_stt_http_server.mcp_server"] = saved

--- a/test/unittests/test_server.py
+++ b/test/unittests/test_server.py
@@ -296,3 +296,50 @@ def test_multi_model_container_shares_transformers(load_stt):
     mm.utterance_transformers = FakeUtteranceService()
     assert mm.process_audio(b"x", "en") == "corrected:transcribed:en"
     assert mm.process_audio(b"x", "de") == "corrected:transcribed:de"
+
+
+# ---------- MCP is opt-in via enable_mcp / --mcp ----------
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_create_app_default_does_not_mount_mcp(load_stt):
+    """Without enable_mcp, /mcp must never be mounted even if the extra is installed."""
+    load_stt.return_value = FakeSTT
+    app, _model = srv.create_app("fake-stt")
+    route_paths = [getattr(r, "path", "") for r in app.routes]
+    assert not any(p == "/mcp" or p.startswith("/mcp/") for p in route_paths)
+
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_create_app_enable_mcp_mounts_route(load_stt):
+    """enable_mcp=True must mount an /mcp route when the mcp extra is available."""
+    pytest.importorskip("fastmcp")
+    load_stt.return_value = FakeSTT
+    app, _model = srv.create_app("fake-stt", enable_mcp=True)
+    route_paths = [getattr(r, "path", "") for r in app.routes]
+    assert any(p == "/mcp" or p.startswith("/mcp/") for p in route_paths)
+
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_create_app_enable_mcp_false_by_default_kwarg(load_stt):
+    """create_app's enable_mcp keyword defaults to False."""
+    import inspect
+    sig = inspect.signature(srv.create_app)
+    assert sig.parameters["enable_mcp"].default is False
+
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_start_stt_server_threads_enable_mcp(load_stt):
+    """start_stt_server must forward enable_mcp through to create_app."""
+    pytest.importorskip("fastmcp")
+    load_stt.return_value = FakeSTT
+    app, _model = srv.start_stt_server("fake-stt", enable_mcp=True)
+    route_paths = [getattr(r, "path", "") for r in app.routes]
+    assert any(p == "/mcp" or p.startswith("/mcp/") for p in route_paths)
+
+
+@patch("ovos_stt_http_server.load_stt_plugin")
+def test_start_stt_server_default_no_mcp(load_stt):
+    load_stt.return_value = FakeSTT
+    app, _model = srv.start_stt_server("fake-stt")
+    route_paths = [getattr(r, "path", "") for r in app.routes]
+    assert not any(p == "/mcp" or p.startswith("/mcp/") for p in route_paths)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

MCP enablement is inconsistent across the four OVOS servers. ovos-tts-server only mounts /mcp when passed --mcp, while ovos-stt-server, the persona server, and the translate server all mount it automatically whenever the mcp extra happens to be importable. Installing an extra shouldn't silently expose a tool endpoint, and operators shouldn't have to remember which server behaves which way, so this brings stt-server in line with tts-server's opt-in flag.

create_app(...) now takes an enable_mcp flag defaulting to False, threaded through from start_stt_server(...), and __main__.py gets a --mcp command-line flag wired to it. The existing ImportError guard around mounting is kept but upgraded from a debug log to an actual warning — asking for --mcp and silently getting nothing is exactly the failure mode worth surfacing, and the message names the install command. The README's extras table, help text, and MCP section are all updated to say the flag is required to actually mount the endpoint, not just the extra.

This is a breaking change for any deployment that installed the mcp extra and relied on it auto-mounting — /mcp stops being exposed until --mcp is passed, with no compatibility env-var fallback, matching the same clean cut made in tts-server. One thing flagged for the maintainer rather than fixed here: the published Docker image for ovos-stt-plugin-onnx-asr installs this package's mcp extra and currently relies on the old auto-mounting behavior, so its ENTRYPOINT will need --mcp added once this lands — there's already an open draft PR (#32) in that repo that will need updating to match, but that repo itself wasn't touched as part of this change.

New and updated tests prove both directions: default settings mount no /mcp route, enable_mcp=True mounts it, and the CLI flag threads through correctly. All 5 new tests were confirmed to fail against the pre-change code and pass after. The full unit suite (extras audio,test,mcp, matching CI) is 346 passed, and the end-to-end suite is 9 passed. The integration suite, which needs credentials and network access for real third-party STT services, wasn't run — it's unrelated to this change either way.
